### PR TITLE
Add SADE community agent under src/agent/community/sade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ dependencies = [
     "func_timeout"
 ]
 
+[project.optional-dependencies]
+# SADE community agent (src/agent/community/sade) drives Claude Code via the SDK.
+sade = ["claude-agent-sdk"]
+
 [project.scripts]
 nika = "nika.codex_cli.main:main"
 

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -36,6 +36,17 @@ src/agent/
 | SDK | `sdk` | TBD (recommended: same two phases) | Anthropic SDK / Cursor SDK | Planned |
 | LangGraph + CLI | `cli` | LangGraph `StateGraph` | `codex exec` subprocess | Implemented |
 
+## Community Agents
+
+Community-contributed agents live under `src/agent/community/<name>/` and implement the
+same `protocols.TroubleshootingAgent` contract.
+
+| Type | CLI name | Orchestration | LLM access | Location |
+|------|----------|---------------|------------|----------|
+| SADE | `sade` | Single Claude Code session, phase-gated workflow + 15-skill library | `claude-agent-sdk` (optional extra `sade`) | `community/sade` |
+
+See `community/sade/README.md` for details and the paper citation.
+
 ## Shared Two-Phase Flow
 
 Every implementation follows the same troubleshooting pipeline:

--- a/src/agent/community/sade/.claude/CLAUDE.md
+++ b/src/agent/community/sade/.claude/CLAUDE.md
@@ -1,0 +1,71 @@
+# Fault Routing and Tool Index
+
+Maps symptom classes to owning fault-family skills, and diagnostic needs to helper scripts. The phase gates themselves are defined in the system prompt; this index complements them rather than replacing them.
+
+## Phase routing
+- Phase 1 (blind start) and Phase 2 (branch) are defined in the system prompt.
+- **Symptom present** → select a fault family from the Fault Index and enter its skill only after the family is implicated by a real symptom.
+- **No symptom after Phase 1** → enter `diagnosis-methodology-skill` first. Return to this index only after broad search surfaces a symptom.
+- `baseline-behavior-skill` is consulted before promoting any observation to a symptom; it does not define a troubleshooting path.
+- Entering a family skill is a commitment that the family is implicated. Do not enter a skill speculatively.
+
+## Fault Index
+
+Each row maps a symptom class to a single owning family. When a symptom plausibly fits two rows, the more specific family owns it; see the disambiguation notes below.
+
+| Symptom pattern | Owning family |
+|---|---|
+| Interface currently DOWN, missing, or detached; active flap script/process; repeated carrier transitions with network-down history | `link-fault-skill` |
+| Packet-length / MTU filter rule observed on a host (`link_fragmentation_disabled` is an iptables length rule) | `acl-skill` |
+| Quiet throughput drop, bandwidth limit, packet corruption, non-default qdisc stack | `tc-fault-skill` |
+| Per-host addressing or identity anomaly on one host (or a small minority): IP, gateway, netmask, missing IP, malformed resolv.conf, static `arp -s`. If every host in a subnet shares the symptom, treat as upstream cascade. | `host-ip-skill` |
+| DHCP server-side fault — daemon dead, missing subnet declaration, server pushing wrong gateway/DNS. Requires direct evidence on the DHCP server; hosts without an IP is not sufficient on its own (possible cascade). | `dhcp-fault-skill` |
+| Concrete duplicate `link/ether`, or an ARP entry that flips between two MACs for one IP | `mac-address-conflict-skill` |
+| Selective protocol or service drop via nft/iptables (HTTP, DNS port, ICMP, BGP, ARP) | `acl-skill` |
+| DNS server-side fault — wrong zone answer, named down, port 53 filtered, or a tc-injected delay on the DNS server's egress (`dns_lookup_latency`) | `dns-fault-skill` |
+| OSPF or FRR fault — missing neighbor, area mismatch, FRR daemon down, OSPF-protocol ACL | `ospf-fault-skill` |
+| BGP advertisement, leak, hijack, ASN, or route-propagation symptom | `bgp-fault-skill` |
+| Load balancer on the hot path and itself implicated (VIP slow or timing out, LB command timeout, failed LB IP lookup, LB CPU/socket spike) | `load-balancer-skill` |
+| A same-role peer uniquely slow, overloaded, CPU-hot, application-delayed, or timing out as an isolated `pressure_sweep`/`infra_sweep` exec failure | `resource-contention-skill` |
+| Device completely silent: ICMP to its known IP fails, shell never opens, AND same-role peers stay clean. Any partial response (ICMP, HTTP, localhost) rules this out and routes to `load-balancer-skill` or `resource-contention-skill` instead. | `host-crash-skill` |
+| Oversized tool output exceeding the inline token budget | `big-return-skill` |
+
+### Disambiguation notes
+- **Subnet-wide versus per-host scope.** `host-ip-skill` covers one host (or a small minority) whose configuration differs from its same-subnet peers. If the same symptom affects every host in a subnet — or every host overall — it is the leaf of an upstream cascade (routing, ACL, link, FRR/control plane). Run `infra_sweep` plus the routing helper that matches the topology (`ospf_snapshot` for OSPF/FRR, `bgp_snapshot` for BGP, or targeted FRR/routing checks if no helper exists) before entering `host-ip-skill` or a DHCP family.
+- `host_incorrect_dns` (host's own resolv.conf is wrong) belongs to `host-ip-skill`, not `dns-fault-skill`. `dns-fault-skill` covers server-side faults only.
+- **DHCP cascade trap.** Hosts without an IP may indicate a genuine DHCP fault or an upstream cascade (broken routing/control plane, ACL, controller, or link making the relay path unreachable). `dhcp-fault-skill` therefore requires direct evidence on the DHCP server — daemon dead via `pgrep` or wrong configuration — and a confirmed path from each affected access gateway or relay to the server before submission.
+- `ospf_acl_block` belongs to `ospf-fault-skill`: the symptom is a broken OSPF adjacency; the ACL is the mechanism. Generic ACL drops on other protocols belong to `acl-skill`.
+- `link_fragmentation_disabled` is implemented as an iptables length filter and therefore surfaces as an ACL rule. It belongs to `acl-skill` despite its name.
+- Transient DHCP no-IP or short lease without direct link evidence stays in `host-ip-skill`; do not reroute to `link-fault-skill`.
+- `carrier_changes` alone is weak history. If the host access interface is UP/present and there is no flap script/process or `Network is down` history, keep a one-host missing-IP symptom in `host-ip-skill`.
+- Slow service response with LB VIP slow and an LB resource spike belongs to `load-balancer-skill`. A single backend slow while the LB is idle belongs to `resource-contention-skill`.
+- **Crash versus contention.** In NIKA, `host_crash` means the injected fault killed/stopped/removed the container. If `pressure_sweep` or `infra_sweep` marks a running web/app server as an isolated timeout/`exec_failed`, route to `resource-contention-skill`; known-IP ICMP success further rules against `host_crash`.
+- **Load-balancer guard.** If a device named or classified as `load_balancer` is flagged by `get_reachability`, `safe_reachability`, `infra_sweep`, `l2_snapshot`, or `pressure_sweep`, enter `load-balancer-skill` before considering `host_crash`, `web_dos_attack`, `receiver_resource_contention`, or `sender_resource_contention`. A shell timeout on the LB is direct LB pressure evidence, not proof of `host_crash`, when ICMP or HTTP still partially works.
+- **Ping-pair / unknown-status caveat.** `ping_pair(src, dst_name)` and `get_reachability` resolve `dst_name` before pinging. Any name-resolution failure on the source — broken or wrong resolver config, a corrupted/missing DNS record, a crashed or unreachable name server, a transient lookup parse error — produces a row with `status="unknown"` and null tx/rx/loss that is indistinguishable from a path failure. Treat these rows as **unconfirmed** until you re-test with a direct-IP probe: `exec_shell(src, "ping -c2 <dst-ip>")` using the IP listed in the same `get_reachability` `hosts` map. If direct-IP succeeds, the symptom lives in the resolver/DNS/host-identity layer, not in routing or link. This rule is topology- and family-agnostic and must run before entering any fault-family skill driven by an `unknown` row.
+
+## Submit signature
+
+`submit(is_anomaly: bool, root_cause_name: list[str], faulty_devices: list[str], confidence: float, summary: str)`.
+Pass actual types (unquoted). `faulty_devices` is always plural. `root_cause_name` values must come from `list_avail_problems()`.
+
+## Tool Index
+
+Enter `diagnosis-methodology-skill` for broad search; its SKILL.md names the helper appropriate to each phase. Each phase provides a **triage** helper (broad, run first) and **specialists** (narrow, run only after triage indicates them).
+
+| Role | Entry point |
+|---|---|
+| Broad-search skill (Phase 4 entry) | `diagnosis-methodology-skill` |
+| Normal-behavior reference / symptom gate | `baseline-behavior-skill` |
+| Oversized-output parser | `big-return-skill` |
+| **Phase A triage** — ACL, addressing, routing, ARP, resolver, link statistics (single pass) | `diagnosis-methodology-skill/scripts/infra_sweep.py` |
+| **Phase A triage** — duplicate `link/ether` detection (`infra_sweep` does not cover this) | `diagnosis-methodology-skill/scripts/l2_snapshot.py` |
+| Phase A specialist — topology and device groups when the task description omits them | `diagnosis-methodology-skill/scripts/network_inventory.py` |
+| **Phase B triage** — routing/control-plane health. Use `ospf_snapshot.py` for OSPF/FRR topologies, `bgp-fault-skill/scripts/bgp_snapshot.py` for BGP topologies, and targeted routing/daemon checks when no protocol-specific helper exists. | matching routing helper |
+| **Phase B triage** — qdisc shape | `diagnosis-methodology-skill/scripts/tc_snapshot.py` |
+| Phase C specialist — `ip route get <target>` with next-hop neighbor state | `diagnosis-methodology-skill/scripts/host_path_snapshot.py` |
+| Phase C specialist — DHCP and link recovery history (temporal) | `diagnosis-methodology-skill/scripts/dhcp_link_history.py` |
+| Phase C specialist — MCP reachability fallback | `diagnosis-methodology-skill/scripts/safe_reachability.py` |
+| **Phase D triage** — combined DNS, HTTP, localhost HTTP, and service-process checks | `diagnosis-methodology-skill/scripts/service_snapshot.py` |
+| **Phase D triage** — stress-tool detection, CPU, socket counts, daemon presence | `diagnosis-methodology-skill/scripts/pressure_sweep.py` |
+| Phase D specialist — majority-minority resolver outlier and per-host nslookup detail | `diagnosis-methodology-skill/scripts/dns_client_snapshot.py` |
+| Phase D specialist — per-host curl timing breakdown | `diagnosis-methodology-skill/scripts/http_client_snapshot.py` |

--- a/src/agent/community/sade/.claude/skills/acl-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/acl-skill/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: acl-skill
+description: Identify ACL and firewall faults from nftables or iptables rules. Use when traffic is selectively blocked by protocol or service (ARP, ICMP, HTTP, DNS, BGP, or packet-size filtering).
+---
+
+# ACL And Firewall Faults
+
+## What This Family Means
+
+- `arp_acl_block`: the device firewall blocks ARP itself, so neighbor discovery fails before normal IP traffic can work.
+- `icmp_acl_block`: the device drops ICMP, so ping-based reachability looks broken even if some non-ICMP traffic could still work.
+- `http_acl_block`: TCP port 80 is blocked on the affected device or path.
+- `dns_port_blocked`: DNS packets on port 53 are blocked by firewall policy.
+- `ospf_acl_block`: OSPF control-plane packets are blocked on a router even though interfaces and config may look normal.
+- `bgp_acl_block`: TCP port 179 is blocked, so BGP traffic cannot form or sustain the session.
+- `link_fragmentation_disabled`: packet-size filtering drops larger packets. This is a firewall/filter rule, not a physical link failure.
+
+## Leading Signals
+
+- The symptom is selective by protocol, not a full device outage.
+- `nft list ruleset` or `iptables -L -n -v` shows a direct drop rule that matches the broken traffic.
+- One implicated host can be healthy locally while the shared router path still owns the actual drop rule.
+
+## Exact Calls
+
+- `python diagnosis-methodology-skill/scripts/infra_sweep.py`
+- `exec_shell(host_name="<flagged-device>", command="nft list ruleset")`
+- `exec_shell(host_name="<flagged-device>", command="iptables -L -n -v")`
+
+`infra_sweep` already runs `nft list ruleset` across every device and tags ACL fingerprints (ARP / OSPF protocol 89 / TCP 179 / TCP 80 / ICMP / packet-length filters). Use it for discovery; use the per-host probes only to confirm on the device infra_sweep flagged.
+
+## Host Vs Router Ownership
+
+- If one host is the repeated suspicious source across many destinations, check that host first.
+- If many sources converge on one destination or one small destination set, inspect that destination once, then check the first shared router or core router with `nft list ruleset`.
+- A clean destination-host ruleset does not clear `icmp_acl_block`; the matching drop rule may live on a router on the shared path.
+
+## Guardrails
+
+- Prefer `nft list ruleset`; many real drops are invisible in `iptables -L`.
+- Check the affected host or first implicated router before broadening.
+- For widespread ICMP-only `unknown` rows, prioritize one router ACL check before OSPF or service-layer expansion.
+- ARP symptoms alone are not enough for `arp_cache_poisoning`; inspect `nft` first.
+- The faulty device is the device that owns the matching drop rule.

--- a/src/agent/community/sade/.claude/skills/baseline-behavior-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/baseline-behavior-skill/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: baseline-behavior-skill
+description: Reference list of signals that look suspicious but are normal testbed behavior. Consult before promoting any observation to a symptom.
+---
+
+# Normal Behavior
+
+## How To Use This Skill
+
+- This skill is an **allowlist** of signals that are normal Kathara behavior and can therefore be dismissed as false positives.
+- **Absence from this list does NOT mean a signal is normal.** If a helper flagged something and you cannot find a matching entry below, treat the flag as real evidence, not as "probably fine because it's small."
+- Use it to avoid false positives, not to choose the troubleshooting order.
+- A baseline note can weaken a theory, but it does not clear a directly implicated device by itself.
+- A single follow-up probe (one ping, one curl) does NOT clear an intermittent symptom such as flapping link, transient drops, or `status=unknown` rows. Intermittent faults need either repeated probes over time or direct evidence on the device.
+
+## Universal
+
+- High `/proc/loadavg` can be host-shared, not container-local, because Kathara containers share the host kernel.
+- `dmesg` is shared host kernel output. Do not use it as per-container evidence.
+- Short DHCP leases are common in these labs and do not themselves indicate a fault.
+- Brief DHCP instability during startup can self-recover.
+- One clean service-layer check does not clear unresolved lower-layer faults.
+
+## Routing And FRR
+
+- `frr_show_running_config` and `frr_show_ip_route` can look healthy even if FRR is dead; check the daemon processes directly.
+- FRR helper tools use `router_name`.
+- If you are unsure of the FRR schema, use `exec_shell(host_name="<router>", command="vtysh -c '...'")`.
+- Cached routes can keep ping working after OSPF or BGP breaks.
+
+## Service And HTTP
+
+- Healthy DNS or HTTP does not clear lower-layer faults (ACL, OSPF, L2 identity).
+- Curl by IP exercises routing plus HTTP only; curl by hostname also exercises DNS.
+- A timeout on a service port that has no listening server is expected; confirm the service actually runs before treating it as a fault.

--- a/src/agent/community/sade/.claude/skills/bgp-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/bgp-fault-skill/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: bgp-fault-skill
+description: Identify BGP routing faults — ASN misconfiguration, missing route advertisement, prefix hijacking, blackhole route leak. Use when reachability failures follow BGP-routed paths, BGP sessions fail to establish, or expected prefixes are missing from peers.
+---
+
+# BGP Faults
+
+## What These Faults Mean
+
+- `bgp_asn_misconfig`: the router's local ASN does not match what its peers expect, so BGP sessions fail to establish.
+- `bgp_missing_route_advertisement`: a `network` statement for a locally-attached prefix is missing from the router's `router bgp` block, so peers never learn that prefix.
+- `bgp_hijacking`: a router loopback claims a service IP/prefix that belongs elsewhere, and BGP advertises it, so traffic is pulled to the wrong router.
+- `bgp_blackhole_route_leak`: a static route to `Null0` is configured **inside FRR** *and* advertised into BGP via a matching `network` statement, attracting traffic that is then dropped.
+- `host_static_blackhole`: a **kernel-level** blackhole route (`ip route ... blackhole`) is installed on a router for a directly-attached host subnet. There is no `ip route ... Null0` line in the FRR running-config; the prefix is the host's own subnet, which BGP already advertises as part of normal baseline config.
+
+## Required tool usage
+
+- FRR MCP tools use `router_name`, not `host_name`.
+- If unsure of the FRR schema, fall back to `exec_shell(host_name="<router>", command="vtysh -c '...'")`.
+- `frr_show_running_config` and `frr_show_ip_route` can look clean when the daemon is dead; they are secondary evidence.
+
+## Guardrails
+
+- A route being "missing or surprising" is not enough. You need direct config or routing-table evidence on the offending router.
+- `bgp_hijacking` requires both the loopback IP AND the advertising `network` statement — one alone is not a hijack.
+- `bgp_blackhole_route_leak` requires **both** an FRR-config `ip route <P> Null0` line **and** a matching `network <P>` advertisement under `router bgp`. A pre-existing `network` for a router's normal attached subnet is not enough on its own.
+- `host_static_blackhole` requires a kernel-level `blackhole` route on the router for an attached host subnet, with **no** corresponding `ip route ... Null0` line in the FRR running-config. If you see a kernel blackhole and immediately conclude `bgp_blackhole_route_leak` because the prefix also appears as a `network` statement, you have misclassified — the `network` statement is normal baseline config; the leak label requires the explicit FRR-config Null0 line.

--- a/src/agent/community/sade/.claude/skills/bgp-fault-skill/scripts/bgp_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/bgp-fault-skill/scripts/bgp_snapshot.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python
+"""
+One-pass BGP coverage helper for the BGP fault skill.
+
+This gathers high-signal BGP data across all discovered routers without
+changing the Kathara MCP server surface:
+- FRR/BGP process status
+- BGP ASN and configured network statements
+- BGP neighbor state summary
+- loopback IPv4 addresses
+- static blackhole / Null0 route lines from the running config
+
+Use it as a fast coverage tool before drilling into a specific router.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SRC_ROOT = Path(__file__).resolve().parents[7]
+REPO_ROOT = SRC_ROOT.parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+BGP_RE = re.compile(r"^\s*router bgp\s+(\d+)\s*$")
+NETWORK_RE = re.compile(r"^\s*network\s+(\S+)(?:\s+route-map\s+(\S+))?\s*$")
+NEIGHBOR_RE = re.compile(r"^\s*neighbor\s+(\S+)\s+remote-as\s+(\d+)\s*$")
+IP_ROUTE_NULL_RE = re.compile(r"^\s*ip route\s+(\S+)\s+(Null0|blackhole)\s*$", re.IGNORECASE)
+LOOPBACK_IPV4_RE = re.compile(r"\binet\s+(\d+\.\d+\.\d+\.\d+/\d+)\b")
+
+
+def _load_api_class():
+    try:
+        from nika.service.kathara import KatharaAPIALL as KatharaAPI  # noqa: E402
+    except ModuleNotFoundError as exc:
+        venv_python = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+        raise SystemExit(
+            f"Missing project dependency '{exc.name}'. "
+            f"Run this script with the project interpreter, e.g. '{venv_python}'."
+        ) from exc
+    return KatharaAPI
+
+# Get routers from the lab API. This assumes that any machine with "router" in its name is a relevant device, which is a common convention in Kathara labs.
+def _load_routers(api: Any) -> list[str]:
+    api.load_machines()
+    return list(api.routers)
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _run(api: Any, router: str, command: str) -> tuple[str, str | None]:
+    raw = api.exec_cmd(router, command)
+    if _command_failed(raw):
+        return raw, raw
+    return raw, None
+
+# The process status check looks for the presence of the main FRR processes (zebra, bgpd, watchfrr) in the process list, which is a strong indicator of whether BGP is likely operational on the router.
+def _process_status(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "ps aux | grep -E 'zebra|bgpd|watchfrr' | grep -v grep")
+    return {
+        "router": router,
+        "raw": raw,
+        "error": error,
+        "zebra": "zebra" in raw,
+        "bgpd": "bgpd" in raw,
+        "watchfrr": "watchfrr" in raw,
+        "healthy": not error and all(name in raw for name in ("zebra", "bgpd", "watchfrr")),
+    }
+
+# The BGP config extraction focuses on the ASN, network statements, neighbor statements, and any static null routes, which can indicate misconfigurations or intentional blackholing.
+def _extract_bgp_config(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show running-config'")
+    asn: str | None = None
+    networks: list[dict[str, str]] = []
+    neighbors: list[dict[str, str]] = []
+    null_routes: list[dict[str, str]] = []
+    in_bgp = False
+
+    for line in raw.splitlines():
+        stripped = line.strip()
+
+        route_match = IP_ROUTE_NULL_RE.match(line)
+        if route_match:
+            null_routes.append({"prefix": route_match.group(1), "target": route_match.group(2)})
+
+        bgp_match = BGP_RE.match(line)
+        if bgp_match:
+            in_bgp = True
+            asn = bgp_match.group(1)
+            continue
+
+        if not in_bgp:
+            continue
+
+        # End of the `router bgp` block: a top-level (column 0) `exit`. The
+        # `!` lines inside the block are internal separators (e.g., before
+        # `address-family ipv4 unicast`), so they must NOT terminate parsing —
+        # otherwise every `network` statement living under address-family is
+        # missed and the snapshot reports `Networks: (none)`.
+        if line.rstrip() == "exit":
+            in_bgp = False
+            continue
+        if stripped == "!":
+            continue
+
+        network_match = NETWORK_RE.match(line)
+        if network_match:
+            record = {"prefix": network_match.group(1)}
+            if network_match.group(2):
+                record["route_map"] = network_match.group(2)
+            networks.append(record)
+            continue
+
+        neighbor_match = NEIGHBOR_RE.match(line)
+        if neighbor_match:
+            neighbors.append({"neighbor": neighbor_match.group(1), "remote_as": neighbor_match.group(2)})
+
+    return {
+        "raw": raw,
+        "error": error,
+        "asn": asn,
+        "networks": networks,
+        "configured_neighbors": neighbors,
+        "null_routes": null_routes,
+    }
+
+# The BGP summary parsing focuses on the neighbor state and prefix counts, which are high-signal indicators of BGP health.
+def _parse_bgp_summary(api: Any, router: str) -> dict[str, Any]:
+    # Prefer JSON output: text columns shift across FRR versions and the
+    # trailing "Desc" field (often "N/A") was being misread as the state.
+    raw, error = _run(api, router, "vtysh -c 'show ip bgp summary json'")
+    neighbors: list[dict[str, Any]] = []
+    if not error:
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            data = None
+        if isinstance(data, dict):
+            af = data.get("ipv4Unicast") or data.get("default", {}).get("ipv4Unicast") or {}
+            peers = af.get("peers", {}) if isinstance(af, dict) else {}
+            for nbr, info in peers.items():
+                if not isinstance(info, dict):
+                    continue
+                state = info.get("state", "Unknown")
+                pfx = info.get("pfxRcd")
+                if state == "Established" and not isinstance(pfx, int):
+                    pfx = info.get("prefixReceivedCount")
+                neighbors.append(
+                    {
+                        "neighbor": nbr,
+                        "remote_as": str(info.get("remoteAs", "")),
+                        "state": state,
+                        "pfxrcd": pfx if isinstance(pfx, int) else None,
+                        "raw_state": state,
+                    }
+                )
+
+    states = Counter(entry["state"] for entry in neighbors)
+    established = sum(1 for entry in neighbors if entry["state"] == "Established")
+    return {
+        "raw": raw,
+        "error": error,
+        "count": len(neighbors),
+        "established_count": established,
+        "states": dict(states),
+        "neighbors": neighbors,
+    }
+
+
+def _loopback_ipv4(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "ip addr show lo")
+    loopbacks = LOOPBACK_IPV4_RE.findall(raw) if not error else []
+    return {
+        "raw": raw,
+        "error": error,
+        "ipv4": loopbacks,
+    }
+
+
+def _router_snapshot(api: Any, router: str) -> dict[str, Any]:
+    process = _process_status(api, router)
+    config = _extract_bgp_config(api, router)
+    summary = _parse_bgp_summary(api, router)
+    loopback = _loopback_ipv4(api, router)
+    return {
+        "router": router,
+        "process": process,
+        "asn": config["asn"],
+        "bgp_networks": config["networks"],
+        "configured_neighbors": config["configured_neighbors"],
+        "null_routes": config["null_routes"],
+        "bgp_summary": summary,
+        "loopback_ipv4": loopback["ipv4"],
+        "errors": {
+            "process": process["error"],
+            "config": config["error"],
+            "summary": summary["error"],
+            "loopback": loopback["error"],
+        },
+    }
+
+
+def _flags(snapshot: dict[str, Any]) -> list[str]:
+    router = snapshot["router"]
+    flags: list[str] = []
+    process = snapshot["process"]
+    summary = snapshot["bgp_summary"]
+    errors = snapshot["errors"]
+
+    for phase, error in errors.items():
+        if error:
+            flags.append(f"{router}: {phase} command failed")
+
+    if not process["healthy"]:
+        missing = [name for name in ("watchfrr", "zebra", "bgpd") if not process[name]]
+        if missing:
+            flags.append(f"{router}: missing FRR process(es): {', '.join(missing)}")
+    if snapshot["null_routes"]:
+        prefixes = ", ".join(item["prefix"] for item in snapshot["null_routes"])
+        flags.append(f"{router}: static null/blackhole route(s): {prefixes}")
+    non_default_lo = [ip for ip in snapshot["loopback_ipv4"] if not ip.startswith("127.")]
+    if non_default_lo:
+        flags.append(f"{router}: loopback IPv4(s): {', '.join(non_default_lo)}")
+    if summary["count"] == 0 and not errors["summary"]:
+        flags.append(f"{router}: zero BGP neighbors in summary")
+    elif summary["established_count"] < summary["count"] and not errors["summary"]:
+        flags.append(f"{router}: non-established BGP neighbors present: {summary['states']}")
+    return flags
+
+
+# The text summary is a human-friendly report of the snapshot data, suitable for quick scanning.
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== BGP SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Routers scanned: {len(payload['routers'])}")
+    if payload["flags"]:
+        lines.append("Flags:")
+        for flag in payload["flags"]:
+            lines.append(f"  - {flag}")
+    else:
+        lines.append("Flags: none")
+
+    lines.append("")
+    for item in payload["routers"]:
+        proc = item["process"]
+        summary = item["bgp_summary"]
+        networks = ", ".join(entry["prefix"] for entry in item["bgp_networks"]) or "(none)"
+        null_routes = ", ".join(entry["prefix"] for entry in item["null_routes"]) or "(none)"
+        loopbacks = ", ".join(item["loopback_ipv4"]) or "(none)"
+        states = ", ".join(f"{state} x{count}" for state, count in sorted(summary["states"].items())) or "(none)"
+        active_errors = [phase for phase, error in item["errors"].items() if error]
+        lines.append(item["router"])
+        lines.append(
+            "  FRR: "
+            f"watchfrr={'yes' if proc['watchfrr'] else 'no'}, "
+            f"zebra={'yes' if proc['zebra'] else 'no'}, "
+            f"bgpd={'yes' if proc['bgpd'] else 'no'}"
+        )
+        lines.append(f"  ASN: {item['asn'] or '(none)'}")
+        lines.append(f"  Networks: {networks}")
+        lines.append(f"  Loopback IPv4: {loopbacks}")
+        lines.append(f"  Null routes: {null_routes}")
+        lines.append(f"  BGP neighbors: {summary['count']} ({states})")
+        lines.append(f"  Command errors: {', '.join(active_errors) if active_errors else 'none'}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# The main entry point gathers snapshots for all discovered routers and prints a summary.
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Get one-pass BGP coverage across all discovered routers.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    routers = _load_routers(api)
+    snapshots = [_router_snapshot(api, router) for router in routers]
+    payload = {
+        "lab_name": api.lab.name,
+        "routers": snapshots,
+        "flags": (
+            ["No routers discovered. Ensure the lab is running and the correct LAB_NAME is selected."]
+            if not routers
+            else [flag for snapshot in snapshots for flag in _flags(snapshot)]
+        ),
+    }
+
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/big-return-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/big-return-skill/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: big-return-skill
+description: Parse oversized MCP tool output. When a tool returns "Output has been saved to <file>.txt" because the result exceeded Claude Code's token limit, run this skill's parser instead of re-reading the file in chunks. Covers `get_reachability` on large topologies and `service_snapshot` on labs with many published hostnames.
+---
+
+# Oversized Tool Outputs
+
+When a tool reports:
+
+```text
+Error: result (N characters) exceeds maximum allowed tokens.
+Output has been saved to <file_path>.txt
+```
+
+Run the parser via the launcher:
+
+```
+python h.py parse_large "<file_path>"
+```
+
+Auto-detection picks one of three formatters based on payload shape:
+
+- **Reachability**: payload carries `hosts` + `results` (covers both `get_reachability()` and `safe_reachability --json`). The reachability formatter groups failures by source/destination, surfaces clustered suspect destinations, and preserves the host/IP inventory.
+- **Service snapshot**: text payload starts with `=== SERVICE SNAPSHOT ===`. The formatter preserves the header (resolver groups, DNS outcome groups, HTTP outcome groups, suspect clients, coverage warnings) and all per-service-device blocks in full, and condenses each per-client block to its nameservers + aggregate flags. The DNS/HTTP outcome groups already aggregate the per-host/per-URL outcomes across clients, so per-zone failure patterns (e.g. one pod's DNS resolves while peers return `no_addresses`) stay visible. To see raw per-row addresses for a single client, rerun `service_snapshot --client <name>` instead of re-reading the saved file.
+- **Generic**: any other oversized JSON falls through to a key/structure summary; plain-text payloads are emitted truncated.
+
+Override with `--type reachability`, `--type service_snapshot`, or `--type generic` only if auto-detection picks the wrong formatter.
+
+## Reading the parser output
+
+- Rows missing `tx`, `rx`, `loss_percent`, or `rtt_avg_ms` are NOT healthy — treat as investigation leads.
+- If many sources show suspicious rows toward a small destination set, that's a shared-path symptom: check the path or the shared upstream router before blaming the source hosts.
+- The parser output is triage guidance, not final proof. Confirm locally before naming a faulty device.

--- a/src/agent/community/sade/.claude/skills/big-return-skill/scripts/parse_large_output.py
+++ b/src/agent/community/sade/.claude/skills/big-return-skill/scripts/parse_large_output.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""
+Parse oversized MCP tool output files saved by Claude Code.
+
+When an MCP tool (e.g. get_reachability) returns data exceeding the
+Claude Code token limit, the CLI saves it to a .txt file. This script
+reads that file and extracts only the anomalies/failures — so the agent
+gets a compact summary instead of wasting turns trying to Read the raw file.
+
+Usage (from Bash tool inside the agent):
+    python parse_large_output.py <saved_file_path> [--type reachability|generic]
+
+Output: compact text summary printed to stdout.
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+
+def _parse_ipv4(ip_value):
+    """Return IPv4 octets for a host inventory value like '10.2.1.53'."""
+    if ip_value is None:
+        return None
+
+    text = str(ip_value).strip()
+    if "/" in text:
+        text = text.split("/", 1)[0]
+
+    parts = text.split(".")
+    if len(parts) != 4:
+        return None
+
+    try:
+        octets = tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+
+    if any(octet < 0 or octet > 255 for octet in octets):
+        return None
+
+    return octets
+
+
+def _format_host_inventory(hosts):
+    """
+    Build compact subnet-oriented host inventory lines.
+
+    This keeps the addressing signal that matters for quiet host-IP faults while
+    staying much smaller than the raw host map.
+    """
+    prefix_groups = defaultdict(list)
+    non_ipv4_hosts = []
+
+    for host_name, host_ip in sorted(hosts.items()):
+        octets = _parse_ipv4(host_ip)
+        if octets is None:
+            non_ipv4_hosts.append((host_name, host_ip))
+            continue
+        prefix = ".".join(str(octet) for octet in octets[:3])
+        prefix_groups[prefix].append(
+            {
+                "host": host_name,
+                "ip": str(host_ip),
+                "last_octet": octets[3],
+            }
+        )
+
+    outlier_candidates = []
+    subnet_lines = []
+
+    def sort_prefix(prefix):
+        return tuple(int(part) for part in prefix.split("."))
+
+    for prefix in sorted(prefix_groups.keys(), key=sort_prefix):
+        entries = sorted(prefix_groups[prefix], key=lambda item: (item["last_octet"], item["host"]))
+        suffixes = [entry["last_octet"] for entry in entries]
+
+        if len(entries) <= 8:
+            members = ", ".join(f"{entry['host']}={entry['ip']}" for entry in entries)
+            subnet_lines.append(f"  {prefix}.* ({len(entries)} hosts): {members}")
+        else:
+            suffix_preview = ", ".join(str(suffix) for suffix in suffixes[:10])
+            subnet_lines.append(
+                f"  {prefix}.* ({len(entries)} hosts): last octets [{suffix_preview}"
+                + (", ..." if len(suffixes) > 10 else "")
+                + "]"
+            )
+
+        # Detect a single last-octet outlier split away from a tight peer cluster.
+        if len(entries) >= 3:
+            gaps = [
+                (entries[i + 1]["last_octet"] - entries[i]["last_octet"], i)
+                for i in range(len(entries) - 1)
+            ]
+            max_gap, gap_index = max(gaps, key=lambda item: item[0])
+            left = entries[: gap_index + 1]
+            right = entries[gap_index + 1 :]
+
+            def cluster_span(cluster):
+                if len(cluster) <= 1:
+                    return 0
+                return cluster[-1]["last_octet"] - cluster[0]["last_octet"]
+
+            if max_gap >= 16:
+                if len(left) == 1 and len(right) >= 2 and cluster_span(right) <= 8:
+                    peer_suffixes = ", ".join(str(entry["last_octet"]) for entry in right)
+                    outlier_candidates.append(
+                        f"  {left[0]['host']}={left[0]['ip']} is isolated from same-/24 peers "
+                        f"in {prefix}.* (peer last octets: {peer_suffixes})"
+                    )
+                elif len(right) == 1 and len(left) >= 2 and cluster_span(left) <= 8:
+                    peer_suffixes = ", ".join(str(entry["last_octet"]) for entry in left)
+                    outlier_candidates.append(
+                        f"  {right[0]['host']}={right[0]['ip']} is isolated from same-/24 peers "
+                        f"in {prefix}.* (peer last octets: {peer_suffixes})"
+                    )
+
+    if non_ipv4_hosts:
+        preview = ", ".join(f"{host}={ip}" for host, ip in non_ipv4_hosts[:8])
+        subnet_lines.append(
+            f"  Non-IPv4/unparsed inventory entries: {preview}"
+            + (" ..." if len(non_ipv4_hosts) > 8 else "")
+        )
+
+    return subnet_lines, outlier_candidates
+
+
+def _format_full_host_inventory(hosts):
+    """Build a complete host=ip inventory sorted by IPv4, then host name."""
+
+    def host_sort_key(item):
+        host_name, host_ip = item
+        octets = _parse_ipv4(host_ip)
+        if octets is None:
+            return (1, str(host_ip), host_name)
+        return (0, *octets, host_name)
+
+    return [f"  {host_name}={host_ip}" for host_name, host_ip in sorted(hosts.items(), key=host_sort_key)]
+
+
+# Parse the too large reachability output: extract failures, anomalies, and a compact host inventory summary.
+def parse_reachability(file_path: str) -> str:
+    """Parse get_reachability() output: extract failures, anomalies, host list."""
+    with open(file_path, "r", encoding="utf-8-sig") as f:
+        data = json.load(f)
+
+    result_str = data.get("result", data) if isinstance(data, dict) else data
+    if isinstance(result_str, str):
+        inner = json.loads(result_str)
+    else:
+        inner = result_str
+
+    hosts = inner.get("hosts", {})
+    results = inner.get("results", [])
+
+    duplicate_host_ips = defaultdict(list)
+    for host_name, host_ip in hosts.items():
+        duplicate_host_ips[str(host_ip)].append(host_name)
+    duplicate_host_ips = {
+        host_ip: sorted(host_names)
+        for host_ip, host_names in duplicate_host_ips.items()
+        if host_ip and len(host_names) > 1
+    }
+
+    # Categorize results
+    failures = []
+    anomalies = []
+    suspicious = []
+    ok_count = 0
+
+    for r in results:
+        loss = r.get("loss_percent")
+        status = (r.get("status") or "").strip().lower()
+        rtt_avg = r.get("rtt_avg_ms")
+
+        # Explicitly bad results.
+        if status == "fail" or loss == 100:
+            failures.append(r)
+            continue
+
+        # Partial loss / slow paths.
+        if isinstance(loss, (int, float)) and loss > 0:
+            anomalies.append(r)
+            continue
+        if isinstance(rtt_avg, (int, float)) and rtt_avg > 100:
+            anomalies.append(r)
+            continue
+
+        # Non-ok status or incomplete measurements are suspicious even when they
+        # don't fit the classic "loss/rtt" buckets. These rows used to be
+        # counted as OK and could hide a broken or overloaded source host.
+        if status and status != "ok":
+            suspicious.append(r)
+            continue
+        if any(r.get(field) is None for field in ("tx", "rx", "loss_percent", "rtt_avg_ms")):
+            suspicious.append(r)
+            continue
+
+        if status == "ok":
+            ok_count += 1
+            continue
+
+        # Missing status should not be summarized as healthy.
+        suspicious.append(r)
+
+    total_hosts = len(hosts.keys()) if isinstance(hosts, dict) else len(hosts)
+    suspicious_by_src = defaultdict(list)
+    suspicious_by_dst = defaultdict(list)
+    for row in suspicious:
+        if row.get("src"):
+            suspicious_by_src[row["src"]].append(row)
+        if row.get("dst"):
+            suspicious_by_dst[row["dst"]].append(row)
+
+    host_lines = _format_full_host_inventory(hosts)
+    subnet_lines, addressing_outliers = _format_host_inventory(hosts)
+
+    lines = []
+    lines.append(f"=== REACHABILITY SUMMARY ===")
+    lines.append(f"Total hosts: {total_hosts}")
+    lines.append(f"Total tests: {len(results)}")
+    lines.append(
+        "OK: "
+        f"{ok_count} | Failures (100% loss): {len(failures)} | "
+        f"Anomalies (partial loss or high RTT): {len(anomalies)} | "
+        f"No-response rows (status!=ok or missing tx/rx/loss/rtt — these ARE evidence of intermittent loss / link flap, NOT measurement artifacts): {len(suspicious)}"
+    )
+    lines.append(f"Potential duplicate IP groups in host inventory: {len(duplicate_host_ips)}")
+    lines.append("")
+
+    if duplicate_host_ips:
+        lines.append("--- POTENTIAL HOST-IP CONFLICTS (inventory-level identity clash) ---")
+        for host_ip, host_names in sorted(duplicate_host_ips.items()):
+            lines.append(f"  {host_ip} is claimed by: {', '.join(host_names)}")
+            overlap_notes = []
+            for host_name in host_names:
+                src_hits = len(suspicious_by_src.get(host_name, []))
+                dst_hits = len(suspicious_by_dst.get(host_name, []))
+                if src_hits or dst_hits:
+                    overlap_notes.append(
+                        f"{host_name} overlaps suspicious reachability rows "
+                        f"(src_hits={src_hits}, dst_hits={dst_hits})"
+                    )
+            for note in overlap_notes:
+                lines.append(f"    {note}")
+        lines.append("  NEXT STEP: run get_host_net_config() on the hosts sharing the same IP and L2 inventory to check for IP conflicts, ARP anomalies, or other identity issues.")
+        lines.append("")
+
+    clustered_suspicious_sources = sorted(
+        (
+            (src_host, len(rows))
+            for src_host, rows in suspicious_by_src.items()
+            if len(rows) >= 2
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+    clustered_suspicious_destinations = sorted(
+        (
+            (dst_host, len(rows))
+            for dst_host, rows in suspicious_by_dst.items()
+            if len(rows) >= 2
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+
+    if clustered_suspicious_sources or clustered_suspicious_destinations:
+        lines.append("--- REACHABILITY TRIAGE TARGETS ---")
+        for src_host, row_count in clustered_suspicious_sources[:5]:
+            lines.append(
+                f"  Source-focused suspect: {src_host} appears in {row_count} suspicious rows"
+            )
+        for dst_host, row_count in clustered_suspicious_destinations[:5]:
+            lines.append(
+                f"  Destination-focused suspect: {dst_host} appears in {row_count} suspicious rows"
+            )
+        primary_src = None
+        primary_src_count = 0
+        if clustered_suspicious_sources:
+            primary_src, primary_src_count = clustered_suspicious_sources[0]
+
+        primary_dst = None
+        primary_dst_count = 0
+        if clustered_suspicious_destinations:
+            primary_dst, primary_dst_count = clustered_suspicious_destinations[0]
+
+        if primary_dst and primary_dst_count > primary_src_count:
+            lines.append(
+                f"  NEXT STEP: inspect {primary_dst} once locally, then check the first shared router "
+                "or core router on that path with nft list ruleset before broader OSPF or service checks."
+            )
+        elif primary_src:
+            lines.append(
+                f"  NEXT STEP: complete the suspect-host local pair on {primary_src}: "
+                "get_host_net_config() plus `ip addr; ip route; ip neigh; ip link`, then compare it "
+                "to one healthy same-subnet peer before any broader service checks."
+            )
+        elif primary_dst:
+            lines.append(
+                f"  NEXT STEP: inspect the path to {primary_dst}, including one implicated router ACL check, "
+                "before broader service checks."
+            )
+        lines.append("")
+
+    if failures:
+        lines.append("--- FAILURES (100% packet loss) ---")
+        for r in failures:
+            lines.append(f"  {r['src']} -> {r['dst']} ({r.get('dst_ip','?')}) | loss={r['loss_percent']}% status={r.get('status','?')}")
+        lines.append("")
+
+    if anomalies:
+        lines.append("--- ANOMALIES (partial loss or RTT > 100ms) ---")
+        for r in anomalies:
+            lines.append(f"  {r['src']} -> {r['dst']} ({r.get('dst_ip','?')}) | loss={r['loss_percent']}% rtt_avg={r.get('rtt_avg_ms','?')}ms")
+        lines.append("")
+
+    if suspicious:
+        lines.append("--- SUSPICIOUS (non-ok status or incomplete measurements) ---")
+        for r in suspicious:
+            lines.append(
+                f"  {r['src']} -> {r['dst']} ({r.get('dst_ip','?')}) | "
+                f"status={r.get('status','?')} tx={r.get('tx','?')} rx={r.get('rx','?')} "
+                f"loss={r.get('loss_percent','?')} rtt_avg={r.get('rtt_avg_ms','?')}"
+            )
+        lines.append("")
+
+    if not failures and not anomalies and not suspicious:
+        lines.append("ALL TESTS PASSED - no reachability issues were surfaced in the sampled ping matrix.")
+        lines.append("Do NOT treat this as proof that the network is healthy; quiet L2/L3 or qdisc faults can still be present.")
+        lines.append("")
+    elif suspicious and not failures and not anomalies:
+        lines.append("No classic ping failures detected, but suspicious/incomplete reachability rows are present.")
+        lines.append("Treat the affected source/destination devices as investigation targets instead of assuming the network is healthy.")
+        lines.append("Do NOT call this result 'mostly clean' and do NOT replace suspect-host local checks with broad HTTP or service sweeps yet.")
+        lines.append("")
+    if duplicate_host_ips:
+        lines.append("Duplicate IP ownership in the reachability host inventory is NOT a sampling artifact.")
+        lines.append("This pattern strongly suggests host_ip_conflict or another identity/addressing fault.")
+        lines.append("")
+
+    if addressing_outliers:
+        lines.append("--- ADDRESSING OUTLIER CANDIDATES ---")
+        lines.extend(addressing_outliers[:12])
+        lines.append(
+            "  NEXT STEP: inspect the outlier host with get_host_net_config() plus "
+            "`ip addr; ip route; ip neigh; ip link`, then compare it to one healthy same-subnet peer "
+            "before deeper service checks."
+        )
+        lines.append("")
+
+    lines.append(f"--- FULL HOST/IP INVENTORY ({total_hosts} hosts) ---")
+    lines.extend(host_lines)
+    lines.append("")
+
+    lines.append(f"--- HOST/IP SUBNET PREVIEW ({total_hosts} hosts) ---")
+    preview_limit = min(len(subnet_lines), 20)
+    lines.extend(subnet_lines[:preview_limit])
+    if len(subnet_lines) > preview_limit:
+        lines.append(f"  ... ({len(subnet_lines) - preview_limit} more subnet groups omitted)")
+
+    return "\n".join(lines)
+
+
+def _looks_like_reachability(file_path: str) -> bool:
+    """Return True if the saved file is a reachability-shaped payload.
+
+    Detection is structural: the inner object carries both a `hosts` mapping
+    and a `results` list. `safe_reachability --json` and the MCP
+    `get_reachability` tool share this shape, so either overflow lands in the
+    reachability formatter.
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    inner = data.get("result", data) if isinstance(data, dict) else data
+    if isinstance(inner, str):
+        try:
+            inner = json.loads(inner)
+        except (json.JSONDecodeError, TypeError):
+            return False
+
+    return (
+        isinstance(inner, dict)
+        and isinstance(inner.get("hosts"), dict)
+        and isinstance(inner.get("results"), list)
+    )
+
+
+def _read_inner_text(file_path: str) -> str | None:
+    """Return the inner string payload from a saved tool-output file, or None."""
+    try:
+        with open(file_path, "r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        try:
+            with open(file_path, "r", encoding="utf-8-sig") as f:
+                return f.read()
+        except OSError:
+            return None
+    inner = data.get("result", data) if isinstance(data, dict) else data
+    if isinstance(inner, str):
+        return inner
+    return None
+
+
+def _summarize_flags_line(flags_line: str) -> str:
+    """Compress a `Flags: ...` line to per-type counts.
+
+    The per-client Flags line lists every flagged hostname/URL (e.g.
+    `Flags: dns_problem:web0.pod0, dns_problem:web1.pod0, http_non_ok:...`),
+    which duplicates the DNS/HTTP outcome groups already emitted earlier.
+    Replace it with one count per flag type so the per-client summary scales
+    with topology size instead of with hostname count.
+    """
+    body = flags_line.split(":", 1)[1].strip() if ":" in flags_line else ""
+    if not body or body.lower() == "none":
+        return "Flags: none"
+    counts: dict[str, int] = defaultdict(int)
+    for token in body.split(","):
+        flag = token.strip().split(":", 1)[0]
+        if flag:
+            counts[flag] += 1
+    if not counts:
+        return "Flags: none"
+    parts = ", ".join(f"{count} {flag}" for flag, count in sorted(counts.items()))
+    return f"Flags: {parts}"
+
+
+def _looks_like_service_snapshot(file_path: str) -> bool:
+    """Return True if the saved file is a service_snapshot text payload.
+
+    The helper's text output (the default mode) starts with the
+    `=== SERVICE SNAPSHOT ===` banner, regardless of lab. JSON output of the
+    same helper falls through to the generic parser.
+    """
+    text = _read_inner_text(file_path)
+    if not isinstance(text, str):
+        return False
+    return text.lstrip().startswith("=== SERVICE SNAPSHOT ===")
+
+
+def parse_service_snapshot(file_path: str) -> str:
+    """Parse oversized service_snapshot text output.
+
+    The bulk of the size comes from per-client blocks: each client emits one
+    DNS row + one HTTP row per published hostname, so on a 4-pod x 7-web lab
+    the per-client section alone is ~25–30 kB. The header already aggregates
+    the same outcomes through the resolver/DNS/HTTP outcome groups, which is
+    the section that actually reveals per-zone failure patterns (e.g. one
+    pod's DNS resolves while peers return `no_addresses`, fingerprinting a
+    server-side `dns_record_error`). The per-service-device blocks are small
+    and carry the named/listener/process evidence used by `dns-fault-skill`.
+
+    Strategy: emit the header (through the `Suspect clients:` line) plus all
+    per-service-device blocks in full, then condense each per-client block to
+    a single line listing its nameservers and aggregate flags. The agent can
+    rerun `service_snapshot --client <name>` to see raw per-row addresses for
+    a specific client when the GROUPS view is not enough.
+    """
+    text = _read_inner_text(file_path)
+    if not isinstance(text, str):
+        raise ValueError("service_snapshot payload not found in saved file")
+
+    lines = text.splitlines()
+
+    suspect_idx: int | None = None
+    for idx, line in enumerate(lines):
+        if line.startswith("Suspect clients:"):
+            suspect_idx = idx
+            break
+    if suspect_idx is None:
+        # Missing the marker - unknown variant. Fall back to emitting the
+        # whole text; the caller will still see more than the 3 kB generic cap.
+        return "\n".join(lines)
+
+    output: list[str] = list(lines[: suspect_idx + 1])
+
+    body = lines[suspect_idx + 1 :]
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in body:
+        if not line.strip():
+            if current:
+                blocks.append(current)
+                current = []
+            continue
+        if not line.startswith((" ", "\t")):
+            if current:
+                blocks.append(current)
+            current = [line]
+        else:
+            if current:
+                current.append(line)
+    if current:
+        blocks.append(current)
+
+    client_blocks: list[list[str]] = []
+    service_blocks: list[list[str]] = []
+    for block in blocks:
+        is_service = any(
+            "Localhost HTTP:" in row or "Processes visible:" in row for row in block
+        )
+        is_client = any(
+            row.lstrip().startswith(("DNS ", "HTTP ", "Nameservers:")) for row in block
+        )
+        if is_service and not is_client:
+            service_blocks.append(block)
+        elif is_client:
+            client_blocks.append(block)
+
+    if client_blocks:
+        output.append("")
+        output.append(
+            f"Per-client blocks ({len(client_blocks)} clients) condensed - the "
+            "DNS/HTTP outcome groups above already aggregate the same per-host/per-URL "
+            "results across clients. To see raw per-row addresses for one client, "
+            "rerun `python h.py service_snapshot --client <name>`."
+        )
+        for block in client_blocks:
+            device = block[0].strip()
+            ns_line = next(
+                (row.strip() for row in block if row.lstrip().startswith("Nameservers:")),
+                "Nameservers: (none)",
+            )
+            flags_line = next(
+                (row.strip() for row in block if row.lstrip().startswith("Flags:")),
+                "Flags: none",
+            )
+            output.append(f"- {device}: {ns_line}; {_summarize_flags_line(flags_line)}")
+
+    if service_blocks:
+        output.append("")
+        for block in service_blocks:
+            output.extend(block)
+            output.append("")
+
+    return "\n".join(output).rstrip() + "\n"
+
+
+def parse_generic(file_path: str) -> str:
+    """Parse any oversized JSON output: print structure + first N entries."""
+    with open(file_path, "r", encoding="utf-8-sig") as f:
+        data = json.load(f)
+
+    result = data.get("result", data) if isinstance(data, dict) else data
+
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            # Plain text — return truncated
+            if len(result) > 3000:
+                return f"[TEXT, {len(result)} chars]\n{result[:3000]}\n... [TRUNCATED]"
+            return result
+
+    if isinstance(result, dict):
+        lines = [f"JSON object with keys: {list(result.keys())}"]
+        for k, v in result.items():
+            if isinstance(v, list):
+                lines.append(f"  {k}: list[{len(v)}] — first entry: {json.dumps(v[0], default=str)[:200] if v else 'empty'}")
+            elif isinstance(v, dict):
+                lines.append(f"  {k}: dict with keys {list(v.keys())[:10]}")
+            else:
+                lines.append(f"  {k}: {str(v)[:200]}")
+        return "\n".join(lines)
+
+    if isinstance(result, list):
+        lines = [f"JSON array with {len(result)} entries"]
+        for item in result[:5]:
+            lines.append(f"  {json.dumps(item, default=str)[:200]}")
+        if len(result) > 5:
+            lines.append(f"  ... ({len(result) - 5} more entries)")
+        return "\n".join(lines)
+
+    return str(result)[:3000]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse oversized MCP tool output")
+    parser.add_argument("file_path", help="Path to the saved .txt file")
+    parser.add_argument(
+        "--type",
+        choices=["reachability", "service_snapshot", "generic", "auto"],
+        default="auto",
+        help=(
+            "Output type for specialized parsing. Default `auto` picks "
+            "`reachability` when the payload carries `hosts` + `results` "
+            "(covers both get_reachability and safe_reachability --json), "
+            "`service_snapshot` when the text starts with the "
+            "`=== SERVICE SNAPSHOT ===` banner, and falls back to `generic` "
+            "otherwise."
+        ),
+    )
+    args = parser.parse_args()
+
+    mode = args.type
+    if mode == "auto":
+        if _looks_like_reachability(args.file_path):
+            mode = "reachability"
+        elif _looks_like_service_snapshot(args.file_path):
+            mode = "service_snapshot"
+        else:
+            mode = "generic"
+
+    try:
+        if mode == "reachability":
+            print(parse_reachability(args.file_path))
+        elif mode == "service_snapshot":
+            print(parse_service_snapshot(args.file_path))
+        else:
+            print(parse_generic(args.file_path))
+    except Exception as e:
+        print(f"ERROR parsing file: {e}", file=sys.stderr)
+        # Fallback: print file size only — do NOT dump raw content
+        # (raw JSON confuses the agent into trying to Read the file)
+        try:
+            with open(args.file_path, "r", encoding="utf-8-sig") as f:
+                content = f.read()
+            print(f"[Fallback] File size: {len(content)} chars. Parse failed: {e}")
+            print("Do NOT try to Read this file — it is too large.")
+            print("Proceed with diagnosis using other tools (exec_shell, etc).")
+        except Exception:
+            print(f"Could not read file. Proceed with other diagnostic tools.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/community/sade/.claude/skills/dhcp-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/dhcp-fault-skill/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: dhcp-fault-skill
+description: Identify DHCP server-side faults — service down, missing subnet declaration, spoofed gateway or DNS pushed by the server. Use when one or more hosts cannot obtain a lease, or hosts received DHCP-supplied values that look wrong.
+---
+
+# DHCP Server-Side Faults
+
+## Direct-evidence requirement
+
+The agent must show direct evidence on the DHCP server before submitting any DHCP fault. Hosts having no IP is downstream — it does NOT prove the DHCP server is the cause.
+
+## Rule out upstream cascade first
+
+A broken path to the DHCP server looks identical to a server-side fault from the affected host's perspective. Before submitting any DHCP fault, confirm the upstream isn't the real cause: the routing / control plane between the affected host and the DHCP server must be healthy, no ACL on the relay path may be dropping lease traffic, and the server itself must be reachable from the host's access gateway or relay. If any of those is broken, the upstream wins.
+
+A host having no IP, an expired lease, or a short `valid_lft` is NOT direct evidence of a DHCP fault by itself — only a dead daemon or a wrong server configuration is.
+
+## Submit on match
+
+When direct evidence on the DHCP server is sufficient AND the upstream cascade has been ruled out, submit. Do not chain extra probes once the family is confirmed.
+
+## Disambiguation
+
+- **DHCP-spoofed vs host-local misconfig.** If the host's wrong gateway/DNS matches what the DHCP server is pushing, this is a DHCP fault and faulty_devices includes both. If the DHCP server's config is correct but the host's `/etc/resolv.conf` or default route differs from what was pushed, that's `host-ip-skill` territory.
+- **dhcp_service_down vs no-route-to-DHCP.** A host without IP plus a DHCP server whose process is alive = upstream cascade, not `dhcp_service_down`. The cascade guard above must pass first.
+- **`systemctl inactive` is not enough.** `systemctl is-active` may report inactive for services that are actually running under a different init pattern. Combine with `pgrep` (or equivalent process check) to confirm the daemon is actually absent before naming a service-down fault.
+- **`dhcp_missing_subnet` vs `dhcp_spoofed_subnet`.** Both produce the same direct evidence (a `subnet` block missing from `dhcpd.conf` for an affected host's subnet). The label follows the scenario's category: `dhcp_missing_subnet` under misconfiguration scenarios, `dhcp_spoofed_subnet` under network-attack scenarios. Check `list_avail_problems()` to see which name is valid for the current scenario before submitting.

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: diagnosis-methodology-skill
+description: Broad-search escalation toolbox. Enter when the blind start surfaces no symptom. Run phases in order, and exit the moment a helper surfaces an anomaly.
+---
+
+# Diagnosis Methodology
+
+## When to enter
+Enter only when reachability is clean and no fault is already implicated. Your first action inside this skill is Phase A. If any helper surfaces an anomaly, leave broad search and pivot to symptom-first diagnosis with that anomaly as the active lead.
+
+## How to run a helper
+```
+python h.py <script> [args]   # h.py lives in your working directory. A bare `python h.py` lists the available scripts.
+```
+Run that command exactly — no `cd` prefix, no `/mnt/c/...` WSL path, no absolute Windows path. The shell is Git-Bash (drives appear as `/c/...`, not `/mnt/c/...`), and rewrites to absolute paths frequently land on a stale tree. If a `python h.py` invocation errors with a path or import failure, do not rewrite the launcher path; verify cwd with `pwd` and report the discrepancy.
+
+Default text mode auto-shows only flagged rows and stays compact on l-size topologies. Use `--json` only for targeted queries on small data; on broad sweeps it exceeds the inline token budget. Every helper accepts `--help`; do not read its source to discover flags.
+
+Base MCP node-local tools use `host_name` even for routers, servers, load balancers, and witnesses; FRR MCP tools use `router_name`; helper scripts often use `--device`. Do not mix these schemas.
+
+## Principles
+- Each phase pairs a **triage helper** (broad, run first) with **specialists** (narrow, run only once triage indicates them). Running a specialist ahead of its triage squanders turns.
+- A helper flag is evidence, not proof. Consult `baseline-behavior-skill` before calling it a symptom, and confirm locally before naming a faulty device.
+- If broad search devolves into raw `exec_shell` fan-outs, a phase has been skipped — return to the appropriate helper.
+
+## Phase A — L2 and infrastructure
+Triage (run both, default scope, no `--group`):
+- [infra_sweep](./scripts/infra_sweep.py): nftables, addressing, routing, ARP, resolver, and link statistics across every device in a single pass.
+- [l2_snapshot](./scripts/l2_snapshot.py): duplicate `link/ether` detection across the lab. `infra_sweep` does not perform duplicate-MAC detection; without this, a `mac_address_conflict` manifests only as generic per-host anomalies.
+Phase A is incomplete until both triage helpers have run and been examined; a clean `infra_sweep` does not clear L2 identity faults.
+
+Specialist: [network_inventory](./scripts/network_inventory.py) — topology overview when the task description omits one.
+
+## Phase B — Control plane and routing
+Triage depends on the topology:
+- OSPF/FRR: [ospf_snapshot](./scripts/ospf_snapshot.py) for FRR health, adjacency, per-interface OSPF state, and area consistency.
+- BGP/FRR: [bgp_snapshot](../bgp-fault-skill/scripts/bgp_snapshot.py) for FRR/BGP process, ASN, neighbor, advertisement, and blackhole evidence.
+- Static, RIP, SDN, or P4: use `network_inventory`, `safe_reachability`, routing-table/controller checks, and targeted daemon probes appropriate to the topology.
+
+Always run [tc_snapshot](./scripts/tc_snapshot.py) when the symptom could be throughput, corruption, jitter, or qdisc shaping.
+
+**Guardrail.** If Phase B reports the fabric healthy but Phase C or D is still broken, verify each implicated router's daemon directly (`systemctl is-active <daemon>`, `pgrep -a <daemon>`) before concluding `is_anomaly=False`.
+
+## Phase C — Host-local (enter only after Phase A implicates a host)
+Specialists: [host_path_snapshot](./scripts/host_path_snapshot.py) (`ip route get <target>` with next-hop neighbor state) · [dhcp_link_history](./scripts/dhcp_link_history.py) (temporal flap and recovery history) · [safe_reachability](./scripts/safe_reachability.py) (fallback for MCP reachability failure).
+
+## Phase D — Service, resolution, and resource pressure
+Triage: [service_snapshot](./scripts/service_snapshot.py) (combined DNS + HTTP + localhost HTTP + service-process, auto-compacting) · [pressure_sweep](./scripts/pressure_sweep.py) (stress-tool detection, CPU, socket counts, daemon presence).
+Specialists: [dns_client_snapshot](./scripts/dns_client_snapshot.py) (majority-minority resolver outlier and per-host per-name lookup detail) · [http_client_snapshot](./scripts/http_client_snapshot.py) (per-host curl timing breakdown).
+
+## Before submitting `is_anomaly=False`
+The Phase A, Phase B, and Phase D triage helpers must each have produced output that was examined. A brief Phase D is acceptable; skipping it is not.
+
+## Exit
+Once a device, path, or service owner is implicated, leave this skill and enter the matching fault-family skill from `CLAUDE.md`.

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/dhcp_link_history.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/dhcp_link_history.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+"""
+Compact DHCP/link-history helper.
+
+Use this when a host looked suspicious in reachability or an early host sweep,
+but current L3 state has already recovered by the time you inspect it.
+
+It combines:
+- current link/IP/default-route state
+- recent host startup / dhclient log history
+- compact pattern extraction for recent DHCP/link trouble
+
+This is especially useful on DHCP topologies where a host can self-heal before
+later inspection, leaving only log history behind.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from typing import Any
+
+from network_inventory import _load_api_class, _resolve_devices
+
+
+ACK_RE = re.compile(r"DHCPACK of (?P<ip>\S+) from (?P<server>\S+)")
+OFFER_RE = re.compile(r"DHCPOFFER of (?P<ip>\S+) from (?P<server>\S+)")
+BOUND_RE = re.compile(r"bound to (?P<ip>\S+) -- renewal in (?P<secs>\d+) seconds\.")
+
+NOTABLE_PATTERNS = (
+    "No DHCPOFFERS received.",
+    "receive_packet failed on eth0: Network is down",
+    "send_packet: Network is down",
+    "send_packet: Network is unreachable",
+    "DHCPOFFER of ",
+    "DHCPACK of ",
+    "bound to ",
+)
+
+HARD_FLAG_PREFIXES = (
+    "current_link_down",
+    "current_no_default_route",
+    "short_valid_lft=",
+    "recent_network_down=",
+    "recent_network_unreachable=",
+    "recent_recovery_after_failure",
+    "current_healthy_but_history_dirty",
+    "current_down_with_history_dirty",
+)
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+# Get current link state, IP address, default route presence, and DHCP lease validity from the device.
+def _current_link_state(api: Any, device: str) -> dict[str, Any]:
+    ip_addr_raw, ip_addr_error = _safe_exec(api, device, "ip addr show dev eth0")
+    route_raw, route_error = _safe_exec(api, device, "ip route")
+
+    current_ip = None
+    try:
+        current_ip = api.get_host_ip(device)
+    except Exception:  # pragma: no cover - depends on live lab state
+        current_ip = None
+
+    link_state = "unknown"
+    if not ip_addr_error:
+        if "state DOWN" in ip_addr_raw:
+            link_state = "DOWN"
+        elif "state UP" in ip_addr_raw:
+            link_state = "UP"
+        elif "LOWER_UP" in ip_addr_raw:
+            link_state = "UP"
+
+    has_default_route = bool(route_raw and any(line.strip().startswith("default ") for line in route_raw.splitlines()))
+
+    valid_lft = None
+    match = re.search(r"valid_lft\s+(\d+)sec", ip_addr_raw)
+    if match:
+        valid_lft = int(match.group(1))
+    elif "valid_lft forever" in ip_addr_raw:
+        valid_lft = "forever"
+
+    return {
+        "link_state": link_state,
+        "current_ip": current_ip,
+        "has_default_route": has_default_route,
+        "valid_lft": valid_lft,
+        "ip_addr_error": ip_addr_error,
+        "route_error": route_error,
+        "ip_addr_raw": ip_addr_raw,
+        "route_raw": route_raw,
+    }
+
+
+# Summarize the DHCP/link history from the startup log
+def _history_summary(log_raw: str) -> dict[str, Any]:
+    lines = [line.rstrip() for line in log_raw.splitlines() if line.strip()]
+    no_offers = sum("No DHCPOFFERS received." in line for line in lines)
+    network_down = sum("Network is down" in line for line in lines)
+    network_unreachable = sum("Network is unreachable" in line for line in lines)
+    offers = [OFFER_RE.search(line).groupdict() for line in lines if OFFER_RE.search(line)]
+    acks = [ACK_RE.search(line).groupdict() for line in lines if ACK_RE.search(line)]
+    bounds = [BOUND_RE.search(line).groupdict() for line in lines if BOUND_RE.search(line)]
+
+    notable_lines = [line for line in lines if any(pattern in line for pattern in NOTABLE_PATTERNS)]
+    notable_lines = notable_lines[-8:]
+
+    # `No DHCPOFFERS received` alone is noisy because many hosts show short-lived
+    # DHCP churn during startup. Treat it as decisive failure only when there was
+    # no later recovery evidence, or when stronger link/path errors also appeared.
+    had_failure = network_down > 0 or network_unreachable > 0 or (no_offers > 0 and not (offers or acks or bounds))
+    had_recovery = bool(offers or acks or bounds)
+
+    return {
+        "no_offers_count": no_offers,
+        "network_down_count": network_down,
+        "network_unreachable_count": network_unreachable,
+        "offer_count": len(offers),
+        "ack_count": len(acks),
+        "bind_count": len(bounds),
+        "had_failure": had_failure,
+        "had_recovery": had_recovery,
+        "notable_lines": notable_lines,
+    }
+
+# broadly summarize the current state and recent history of the device's DHCP/link status, and extract flags for suspicious conditions.
+def _device_snapshot(api: Any, device: str, lines: int) -> dict[str, Any]:
+    current = _current_link_state(api, device)
+    log_raw, log_error = _safe_exec(api, device, f"tail -n {lines} /var/log/startup.log 2>/dev/null")
+    history = _history_summary(log_raw) if not log_error else None
+
+    flags: list[str] = []
+    if current["link_state"] == "DOWN":
+        flags.append("current_link_down")
+    if not current["has_default_route"]:
+        flags.append("current_no_default_route")
+    if isinstance(current["valid_lft"], int) and current["valid_lft"] <= 15:
+        flags.append(f"short_valid_lft={current['valid_lft']}s")
+
+    if history:
+        noisy_no_offer = history["no_offers_count"] and not (
+            history["network_down_count"]
+            or history["network_unreachable_count"]
+            or current["link_state"] == "DOWN"
+            or not current["has_default_route"]
+            or (isinstance(current["valid_lft"], int) and current["valid_lft"] <= 15)
+        )
+        if history["no_offers_count"] and not noisy_no_offer:
+            flags.append(f"recent_no_dhcp_offers={history['no_offers_count']}")
+        if history["network_down_count"]:
+            flags.append(f"recent_network_down={history['network_down_count']}")
+        if history["network_unreachable_count"]:
+            flags.append(f"recent_network_unreachable={history['network_unreachable_count']}")
+        if history["had_failure"] and history["had_recovery"]:
+            flags.append("recent_recovery_after_failure")
+        if current["link_state"] == "UP" and current["has_default_route"] and history["had_failure"]:
+            flags.append("current_healthy_but_history_dirty")
+        if current["link_state"] == "DOWN" and history["had_failure"]:
+            flags.append("current_down_with_history_dirty")
+
+    return {
+        "device": device,
+        "current": {
+            "link_state": current["link_state"],
+            "current_ip": current["current_ip"],
+            "has_default_route": current["has_default_route"],
+            "valid_lft": current["valid_lft"],
+        },
+        "history": history,
+        "flags": flags,
+        # Raw `ip addr` / `ip route` echoes are intentionally NOT re-emitted;
+        # those are infra_sweep's job. We keep the startup-log tail because
+        # it's this script's unique artifact.
+        "startup_log_tail": log_raw,
+        "errors": {
+            "ip_addr": current["ip_addr_error"],
+            "ip_route": current["route_error"],
+            "startup_log": log_error,
+        },
+    }
+
+
+def _flag_score(item: dict[str, Any]) -> tuple[int, int]:
+    flags = item.get("flags", [])
+    hard = sum(any(flag.startswith(prefix) for prefix in HARD_FLAG_PREFIXES) for flag in flags)
+    return hard, len(flags)
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    flagged = [item for item in payload["devices"] if item["flags"]]
+    flagged_sorted = sorted(flagged, key=_flag_score, reverse=True)
+    flag_counts: dict[str, int] = {}
+    for item in flagged:
+        for flag in item["flags"]:
+            flag_counts[flag] = flag_counts.get(flag, 0) + 1
+
+    lines.append("=== DHCP/LINK HISTORY SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Devices scanned: {len(payload['devices'])}")
+    lines.append(f"Devices with suspicious history/state: {len(flagged)}")
+    if flag_counts:
+        lines.append("Flag counts:")
+        for flag, count in sorted(flag_counts.items(), key=lambda pair: (-pair[1], pair[0])):
+            lines.append(f"  {flag}: {count}")
+    lines.append("")
+
+    devices_to_show = payload["devices"] if payload["include_clean"] else flagged_sorted
+    if not devices_to_show:
+        lines.append("No suspicious DHCP/link history found in the selected devices.")
+        return "\n".join(lines).rstrip() + "\n"
+
+    max_devices = payload["max_devices"] if not payload["include_clean"] else len(devices_to_show)
+    shown_devices = devices_to_show[:max_devices]
+    omitted = len(devices_to_show) - len(shown_devices)
+
+    for item in shown_devices:
+        current = item["current"]
+        history = item["history"]
+        route_text = "yes" if current["has_default_route"] else "no"
+        valid_lft = current["valid_lft"] if current["valid_lft"] is not None else "(unknown)"
+
+        lines.append(item["device"])
+        lines.append(
+            "  Current: "
+            f"link={current['link_state']} ip={current['current_ip'] or '(none)'} "
+            f"default_route={route_text} valid_lft={valid_lft}"
+        )
+        if history:
+            lines.append(
+                "  History: "
+                f"no_offers={history['no_offers_count']} "
+                f"network_down={history['network_down_count']} "
+                f"network_unreachable={history['network_unreachable_count']} "
+                f"offers={history['offer_count']} acks={history['ack_count']} binds={history['bind_count']}"
+            )
+            if history["notable_lines"]:
+                lines.append("  Recent notable lines:")
+                for line in history["notable_lines"][-payload["max_notable_lines"] :]:
+                    lines.append(f"    {line}")
+        lines.append(f"  Flags: {', '.join(item['flags']) if item['flags'] else 'none'}")
+        lines.append("")
+
+    if omitted > 0:
+        remaining_preview = ", ".join(item["device"] for item in devices_to_show[max_devices : max_devices + 8])
+        lines.append(f"... {omitted} more suspicious devices omitted")
+        if remaining_preview:
+            lines.append(f"Next omitted devices: {remaining_preview}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact DHCP/link-history helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("device_args", nargs="*", help="Optional device names to scan.")
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=["hosts", "routers", "switches", "servers", "bmv2_switches", "ovs_switches", "sdn_controllers", "all"],
+        dest="groups",
+    )
+    parser.add_argument("--lines", type=int, default=80)
+    parser.add_argument("--show-clean", action="store_true")
+    parser.add_argument("--max-devices", type=int, default=12)
+    parser.add_argument("--max-notable-lines", type=int, default=3)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    if args.device_args:
+        if args.devices:
+            parser.error("Use positional devices or --device, not both.")
+        args.devices = list(args.device_args)
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    groups = args.groups if args.groups else ([] if args.devices else ["hosts"])
+    devices = _resolve_devices(api, args.devices, groups, expand_neighbors=False)
+
+    payload = {
+        "lab_name": api.lab.name,
+        "include_clean": args.show_clean,
+        "max_devices": args.max_devices,
+        "max_notable_lines": args.max_notable_lines,
+        "devices": [_device_snapshot(api, device, args.lines) for device in devices],
+    }
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/dns_client_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/dns_client_snapshot.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python
+"""
+Compact DNS client snapshot helper.
+
+This script is designed to catch host-local DNS faults that stay invisible when
+the agent only samples a few healthy endpoints. It scans a selected device set
+(`hosts` by default), groups devices by resolver configuration, and verifies
+hostname resolution either for a requested target or for the live published
+service names discovered from the DNS server.
+
+Primary use case:
+- `host_incorrect_dns` in large DHCP-based enterprise topologies where only one
+  host has a poisoned `/etc/resolv.conf`.
+- `dns_record_error` during broad-search escalation when the caller provides no
+  explicit hostname and still expects DNS correctness to be checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from typing import Any
+
+from network_inventory import _lab_groups, _load_api_class, _resolve_devices
+
+
+IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+ZONE_A_RECORD_RE = re.compile(r"^([A-Za-z0-9_-]+|@)\s+IN\s+A\s+((?:\d{1,3}\.){3}\d{1,3})\s*$")
+ZONE_BLOCK_RE = re.compile(r'zone\s+"([^"]+)"\s+IN\s*\{.*?file\s+"([^"]+)";', re.IGNORECASE | re.DOTALL)
+AUTO_FULL_LOOKUP_MAX_DEVICES = 12
+AUTO_FULL_LOOKUP_MAX_HOSTNAMES = 8
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+# Parse nameservers from resolv.conf content, ignoring comments and blank lines.
+def _parse_nameservers(raw: str) -> list[str]:
+    nameservers = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("nameserver "):
+            nameservers.append(stripped.split(None, 1)[1])
+    return nameservers
+
+
+# Parse nslookup ouput to extract resolved IP addresses, handling different output formats and error cases.
+def _parse_nslookup_addresses(raw: str) -> list[str]:
+    addresses = []
+    after_name = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("Name:"):
+            after_name = True
+            continue
+        if not after_name:
+            continue
+        if stripped.startswith(("Address:", "Addresses:")):
+            tail = stripped.split(":", 1)[1].strip()
+            for match in IP_RE.findall(tail):
+                if match not in addresses:
+                    addresses.append(match)
+            continue
+        if IP_RE.fullmatch(stripped) and stripped not in addresses:
+            addresses.append(stripped)
+    return addresses
+
+
+def _parse_zone_a_records(raw: str) -> list[tuple[str, str]]:
+    records: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        stripped = line.split(";", 1)[0].strip()
+        if not stripped:
+            continue
+        match = ZONE_A_RECORD_RE.match(stripped)
+        if match:
+            records.append((match.group(1), match.group(2)))
+    return records
+
+
+def _reverse_zone(zone: str) -> bool:
+    normalized = zone.lower().rstrip(".")
+    return normalized.endswith(".in-addr.arpa") or normalized.endswith(".ip6.arpa")
+
+
+_BIND_DEFAULT_ZONES = frozenset({"0", "127", "255", "empty", "root"})
+
+
+def _zone_from_path(path: str) -> str | None:
+    filename = path.rsplit("/", 1)[-1].strip()
+    if not filename or filename.endswith(".bak"):
+        return None
+    if filename.startswith("db."):
+        zone = filename[3:]
+    elif filename.endswith(".zone"):
+        zone = filename[:-5]
+    else:
+        return None
+    if not zone or _reverse_zone(zone):
+        return None
+    # Skip bind9 default empty-zone files (db.0, db.127, db.255, db.empty,
+    # db.root). They're not real service zones; including them would generate
+    # bogus hostnames like "web0.127" from the inferred-hostname path.
+    if zone in _BIND_DEFAULT_ZONES:
+        return None
+    return zone
+
+
+def _bind_zone_sources(api: Any, dns_device: str) -> list[tuple[str, str]]:
+    candidates: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for config_path in (
+        "/etc/bind/named.conf",
+        "/etc/bind/named.conf.local",
+        "/etc/bind/named.conf.default-zones",
+    ):
+        config_raw, config_error = _safe_exec(api, dns_device, f"cat {config_path} 2>/dev/null")
+        if config_error:
+            continue
+        for zone, path in ZONE_BLOCK_RE.findall(config_raw):
+            normalized_zone = zone.strip().rstrip(".")
+            normalized_path = path.strip()
+            if not normalized_zone or not normalized_path or _reverse_zone(normalized_zone):
+                continue
+            key = (normalized_zone, normalized_path)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(key)
+
+    file_list_raw, file_list_error = _safe_exec(api, dns_device, "find /etc/bind -maxdepth 2 -type f 2>/dev/null")
+    if file_list_error:
+        return candidates
+
+    for raw_path in file_list_raw.splitlines():
+        path = raw_path.strip()
+        if not path:
+            continue
+        zone = _zone_from_path(path)
+        if not zone:
+            continue
+        key = (zone, path)
+        if key not in seen:
+            seen.add(key)
+            candidates.append(key)
+
+    return candidates
+
+
+def _resolver_key(nameservers: list[str]) -> str:
+    return ",".join(nameservers) if nameservers else "(none)"
+
+
+def _infer_expected_nameserver(records: list[dict[str, Any]]) -> tuple[str | None, int]:
+    counter = Counter()
+    for record in records:
+        if record["nameservers"]:
+            counter[record["nameservers"][0]] += 1
+    if not counter:
+        return None, 0
+    expected, count = counter.most_common(1)[0]
+    return expected, count
+
+
+def _pick_hosts_for_dns_checks(
+    records: list[dict[str, Any]],
+    suspect_hosts: list[str],
+    healthy_sample_size: int,
+    per_resolver_group: bool = False,
+) -> list[str]:
+    selected = list(suspect_hosts)
+    if healthy_sample_size <= 0:
+        return list(dict.fromkeys(selected))
+
+    healthy_hosts = [record for record in records if record["device"] not in suspect_hosts and not record["error"]]
+    if per_resolver_group:
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for record in healthy_hosts:
+            grouped[record["resolver_key"]].append(record["device"])
+        for devices in grouped.values():
+            selected.extend(devices[:healthy_sample_size])
+    else:
+        selected.extend(record["device"] for record in healthy_hosts[:healthy_sample_size])
+    return list(dict.fromkeys(selected))
+
+
+def _default_service_devices(api: Any) -> list[str]:
+    inventory = _lab_groups(api)
+    devices: list[str] = []
+    devices.extend(sorted(inventory["servers"].get("web", [])))
+    devices.extend(sorted(inventory["servers"].get("load_balancer", [])))
+    return list(dict.fromkeys(devices))
+
+
+def _device_ip(api: Any, device: str) -> str | None:
+    try:
+        ip = api.get_host_ip(device, with_prefix=False)
+    except TypeError:
+        ip = api.get_host_ip(device)
+    except Exception:
+        return None
+    if not ip:
+        return None
+    return ip.split("/", 1)[0]
+
+
+def _expected_service_ips(api: Any) -> set[str]:
+    addresses: set[str] = set()
+    for device in _default_service_devices(api):
+        if ip := _device_ip(api, device):
+            addresses.add(ip)
+    return addresses
+
+
+def _inferred_service_hostnames(api: Any, zones: list[str]) -> list[str]:
+    hostnames: list[str] = []
+    service_devices = _default_service_devices(api)
+
+    for zone in zones:
+        normalized_zone = zone.strip().rstrip(".")
+        if not normalized_zone or _reverse_zone(normalized_zone):
+            continue
+        for device in service_devices:
+            device_l = device.lower()
+            if "load_balancer" in device_l:
+                hostname = f"web99.{normalized_zone}"
+            else:
+                web_index = _web_index_from_device(device_l)
+                if web_index is None:
+                    continue
+                hostname = f"web{web_index}.{normalized_zone}"
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+
+    return hostnames
+
+
+def _published_hostnames(api: Any) -> list[str]:
+    inventory = _lab_groups(api)
+    dns_devices = sorted(inventory["servers"].get("dns", []))
+    hostnames: list[str] = []
+    inferred_hostnames: list[str] = []
+    expected_service_ips = _expected_service_ips(api)
+
+    for dns_device in dns_devices:
+        zone_sources = _bind_zone_sources(api, dns_device)
+        zone_names = [zone for zone, _path in zone_sources]
+        for hostname in _inferred_service_hostnames(api, zone_names):
+            if hostname not in inferred_hostnames:
+                inferred_hostnames.append(hostname)
+
+        for zone, path in zone_sources:
+            zone_raw, zone_error = _safe_exec(api, dns_device, f"cat {path} 2>/dev/null")
+            if zone_error:
+                continue
+            for label, record_ip in _parse_zone_a_records(zone_raw):
+                lowered = label.lower()
+                if label == "@" or lowered.startswith("ns"):
+                    continue
+                if expected_service_ips and record_ip not in expected_service_ips and not lowered.startswith("web"):
+                    continue
+                hostname = f"{label}.{zone}"
+                if hostname not in hostnames:
+                    hostnames.append(hostname)
+
+    if hostnames:
+        for hostname in inferred_hostnames:
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+        return hostnames
+    return inferred_hostnames
+
+
+def _hostname_tokens(hostname: str) -> tuple[str, list[str]]:
+    label, _, zone = hostname.lower().partition(".")
+    zone_tokens = [token for token in re.split(r"[^a-z0-9]+", zone) if token]
+    return label, zone_tokens
+
+
+def _web_index_from_label(label: str) -> str | None:
+    match = re.match(r"web(\d+)", label)
+    return match.group(1) if match else None
+
+
+def _web_index_from_device(device: str) -> str | None:
+    for pattern in (r"web_server_(\d+)", r"webserver(\d+)", r"web_(\d+)"):
+        match = re.search(pattern, device.lower())
+        if match:
+            return match.group(1)
+    return None
+
+
+def _device_matches_hostname(device: str, hostname: str) -> bool:
+    device_l = device.lower()
+    label, zone_tokens = _hostname_tokens(hostname)
+    label_index = _web_index_from_label(label)
+
+    if "load_balancer" in device_l:
+        return label.startswith("web") and label.endswith("99")
+
+    if "web" not in label or "web" not in device_l:
+        return False
+
+    device_index = _web_index_from_device(device_l)
+    if label_index and device_index and label_index != device_index:
+        return False
+    if label_index and not device_index:
+        return False
+
+    scoped_zone_tokens = [token for token in zone_tokens if token.startswith("pod") or any(ch.isdigit() for ch in token)]
+    if scoped_zone_tokens and not all(token in device_l for token in scoped_zone_tokens):
+        return False
+
+    return True
+
+
+def _expected_addresses_by_hostname(api: Any, hostnames: list[str]) -> dict[str, str]:
+    service_devices = _default_service_devices(api)
+    ip_by_device = {device: ip for device in service_devices if (ip := _device_ip(api, device))}
+    expected: dict[str, str] = {}
+
+    for hostname in hostnames:
+        candidates = [device for device in service_devices if _device_matches_hostname(device, hostname)]
+        candidates = [device for device in candidates if device in ip_by_device]
+        if len(candidates) == 1:
+            expected[hostname] = ip_by_device[candidates[0]]
+
+    return expected
+
+
+def _nslookup_snapshot(
+    api: Any,
+    device: str,
+    hostname: str,
+    expected_address: str | None,
+    expected_service_ips: set[str],
+) -> dict[str, Any]:
+    raw, error = _safe_exec(api, device, f"timeout 5 nslookup {hostname} 2>&1")
+    addresses = _parse_nslookup_addresses(raw) if not error else []
+    flags: list[str] = []
+    if error:
+        flags.append("nslookup_failed")
+    if not addresses:
+        flags.append("nslookup_no_addresses")
+    if expected_address and addresses and expected_address not in addresses:
+        flags.append("nslookup_wrong_address")
+    elif not expected_address and addresses and expected_service_ips and not set(addresses).issubset(expected_service_ips):
+        flags.append("nslookup_unexpected_service_address")
+    return {
+        "device": device,
+        "hostname": hostname,
+        "addresses": addresses,
+        "error": error,
+        "flags": flags,
+        "raw": raw,
+        "expected_address": expected_address,
+    }
+
+
+def _lookup_signature(lookup: dict[str, Any]) -> str:
+    if lookup["flags"]:
+        return "problem:" + ",".join(sorted(lookup["flags"]))
+    if lookup["addresses"]:
+        return "answer:" + ",".join(lookup["addresses"])
+    return "answer:(none)"
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== DNS CLIENT SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Devices scanned: {len(payload['devices'])}")
+    lines.append(f"Expected nameserver: {payload['expected_nameserver'] or '(unknown)'}")
+    if payload["expected_nameserver_count"]:
+        lines.append(
+            f"Expected nameserver support: {payload['expected_nameserver_count']}/{len(payload['devices'])} devices"
+        )
+    if payload["hostnames_checked"]:
+        lines.append(f"Hostnames checked: {', '.join(payload['hostnames_checked'])}")
+    if payload["lookup_devices"]:
+        lines.append(f"Lookup devices: {', '.join(payload['lookup_devices'])}")
+    if payload["lookup_mode"]:
+        lines.append(f"Lookup mode: {payload['lookup_mode']}")
+    if payload["auto_discovered_hostnames"]:
+        lines.append("Hostname mode: auto-discovered from live DNS zones")
+    elif payload["hostnames_checked"]:
+        lines.append("Hostname mode: explicit target")
+    lines.append("")
+
+    # Cross-client resolver grouping and lookup-outcome grouping are produced
+    # by service_snapshot's triage view; this script does not re-emit them.
+    # Our unique contribution is the majority-resolver inference (above) and
+    # the per-host per-name nslookup detail (below).
+
+    if payload["suspect_hosts"]:
+        lines.append("Suspect hosts:")
+        for record in payload["devices"]:
+            if record["device"] not in payload["suspect_hosts"]:
+                continue
+            nameserver_text = ", ".join(record["nameservers"]) if record["nameservers"] else "(none)"
+            flags_text = ", ".join(record["flags"]) if record["flags"] else "none"
+            lines.append(f"- {record['device']}: nameservers={nameserver_text} flags={flags_text}")
+            for hostname, lookup in record["nslookups"].items():
+                addr_text = ", ".join(lookup["addresses"]) if lookup["addresses"] else "(none)"
+                lookup_flags = ", ".join(lookup["flags"]) if lookup["flags"] else "none"
+                expected_text = lookup["expected_address"] or "(service-pool check)"
+                lines.append(
+                    f"  nslookup {hostname}: addresses={addr_text} expected={expected_text} flags={lookup_flags}"
+                )
+    else:
+        lines.append("Suspect hosts: none")
+
+    healthy_checks = [
+        record for record in payload["devices"]
+        if record["nslookups"] and record["device"] not in payload["suspect_hosts"]
+    ]
+    if healthy_checks:
+        lines.append("")
+        lines.append("Healthy verification sample:")
+        for record in healthy_checks:
+            lines.append(f"- {record['device']}:")
+            for hostname, lookup in record["nslookups"].items():
+                addr_text = ", ".join(lookup["addresses"]) if lookup["addresses"] else "(none)"
+                expected_text = lookup["expected_address"] or "(service-pool check)"
+                lines.append(f"  {hostname} -> {addr_text} expected={expected_text}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact DNS client snapshot helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("hostname_arg", nargs="?", help="Optional hostname shortcut.")
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=["hosts", "routers", "switches", "servers", "bmv2_switches", "ovs_switches", "sdn_controllers", "all"],
+        dest="groups",
+    )
+    parser.add_argument("--expected-nameserver")
+    parser.add_argument("--hostname")
+    parser.add_argument("--expected-address")
+    parser.add_argument("--target-device")
+    parser.add_argument("--healthy-sample-size", type=int, default=1)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    if args.hostname and args.hostname_arg:
+        parser.error("Use either the positional hostname or --hostname, not both.")
+    hostname = args.hostname or args.hostname_arg
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    devices = _resolve_devices(api, args.devices, args.groups or ["hosts"], expand_neighbors=False)
+    expected_service_ips = _expected_service_ips(api)
+    hostnames_to_check = [hostname] if hostname else _published_hostnames(api)
+    auto_discovered_hostnames = not hostname and bool(hostnames_to_check)
+
+    expected_addresses: dict[str, str] = {}
+    if hostname:
+        expected_address = args.expected_address
+        if not expected_address and args.target_device:
+            try:
+                expected_address = api.get_host_ip(args.target_device)
+            except Exception:
+                expected_address = None
+        if expected_address:
+            expected_addresses[hostname] = expected_address
+    elif hostnames_to_check:
+        expected_addresses = _expected_addresses_by_hostname(api, hostnames_to_check)
+
+    records: list[dict[str, Any]] = []
+    for device in devices:
+        resolv_raw, error = _safe_exec(api, device, "cat /etc/resolv.conf 2>/dev/null")
+        nameservers = _parse_nameservers(resolv_raw) if not error else []
+        records.append(
+            {
+                "device": device,
+                "nameservers": nameservers,
+                "resolver_key": _resolver_key(nameservers),
+                "error": error,
+                "flags": ["resolver_collection_failed"] if error else [],
+                "records": {"resolv_conf": resolv_raw},
+                "nslookups": {},
+            }
+        )
+
+    expected_nameserver = args.expected_nameserver
+    expected_nameserver_count = 0
+    if expected_nameserver:
+        expected_nameserver_count = sum(
+            1 for record in records if expected_nameserver in record["nameservers"]
+        )
+    else:
+        expected_nameserver, expected_nameserver_count = _infer_expected_nameserver(records)
+
+    suspect_hosts: list[str] = []
+    for record in records:
+        if record["error"]:
+            suspect_hosts.append(record["device"])
+            continue
+        if not record["nameservers"]:
+            record["flags"].append("no_nameserver")
+            suspect_hosts.append(record["device"])
+            continue
+        if expected_nameserver and expected_nameserver not in record["nameservers"]:
+            record["flags"].append("unexpected_nameserver")
+            suspect_hosts.append(record["device"])
+
+    lookup_hosts: list[str] = []
+    lookup_mode = "none"
+    if hostnames_to_check:
+        auto_full_lookup = (
+            auto_discovered_hostnames
+            and len(records) <= AUTO_FULL_LOOKUP_MAX_DEVICES
+            and len(hostnames_to_check) <= AUTO_FULL_LOOKUP_MAX_HOSTNAMES
+        )
+        if auto_full_lookup:
+            lookup_hosts = [record["device"] for record in records if not record["error"]]
+            lookup_mode = "full client sweep"
+        else:
+            lookup_hosts = _pick_hosts_for_dns_checks(
+                records,
+                suspect_hosts,
+                max(args.healthy_sample_size, 0),
+                per_resolver_group=auto_discovered_hostnames,
+            )
+            lookup_mode = "resolver-group sample" if auto_discovered_hostnames else "targeted sample"
+        for record in records:
+            if record["device"] not in lookup_hosts:
+                continue
+            for current_hostname in hostnames_to_check:
+                lookup = _nslookup_snapshot(
+                    api,
+                    record["device"],
+                    current_hostname,
+                    expected_addresses.get(current_hostname),
+                    expected_service_ips,
+                )
+                record["nslookups"][current_hostname] = lookup
+                if lookup["flags"] and record["device"] not in suspect_hosts:
+                    suspect_hosts.append(record["device"])
+
+        for current_hostname in hostnames_to_check:
+            signature_counter = Counter(
+                _lookup_signature(record["nslookups"][current_hostname])
+                for record in records
+                if current_hostname in record["nslookups"]
+            )
+            if len(signature_counter) <= 1:
+                continue
+            majority_signature, _ = signature_counter.most_common(1)[0]
+            for record in records:
+                lookup = record["nslookups"].get(current_hostname)
+                if not lookup:
+                    continue
+                if _lookup_signature(lookup) == majority_signature:
+                    continue
+                if "nslookup_inconsistent_with_peer_group" not in lookup["flags"]:
+                    lookup["flags"].append("nslookup_inconsistent_with_peer_group")
+                if record["device"] not in suspect_hosts:
+                    suspect_hosts.append(record["device"])
+
+    resolver_groups: dict[str, list[str]] = defaultdict(list)
+    for record in records:
+        resolver_groups[record["resolver_key"]].append(record["device"])
+
+    lookup_groups: dict[str, dict[str, list[str]]] = {}
+    for current_hostname in hostnames_to_check:
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for record in records:
+            lookup = record["nslookups"].get(current_hostname)
+            if not lookup:
+                continue
+            grouped[_lookup_signature(lookup)].append(record["device"])
+        if grouped:
+            lookup_groups[current_hostname] = {
+                key: sorted(value) for key, value in sorted(grouped.items())
+            }
+
+    payload = {
+        "lab_name": api.lab.name,
+        "hostnames_checked": hostnames_to_check,
+        "lookup_devices": lookup_hosts,
+        "lookup_mode": lookup_mode,
+        "auto_discovered_hostnames": auto_discovered_hostnames,
+        "expected_nameserver": expected_nameserver,
+        "expected_nameserver_count": expected_nameserver_count,
+        "suspect_hosts": sorted(set(suspect_hosts)),
+        "resolver_groups": {key: sorted(value) for key, value in sorted(resolver_groups.items())},
+        "lookup_groups": lookup_groups,
+        "devices": records,
+    }
+
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/host_path_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/host_path_snapshot.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+"""
+Route-selection drill-down for one or more hosts.
+
+Use this ONLY when you already have a suspicious host and a specific
+destination, and you need to see exactly which interface / next-hop /
+source IP the kernel picks. Broader host L3 state (interfaces, routes,
+resolver, ARP) is owned by `infra_sweep --device <host>`, which covers
+every device with one compound exec — this helper does not duplicate it.
+
+Unique output:
+- `ip route get <target>` result per scanned host
+- matching neighbor state (ARP/ND) for the next-hop the kernel chose
+- a one-line L3 context summary (IPv4 present / default route present /
+  resolver count) so the route-get answer can be read without flipping to
+  another helper
+
+If no target is supplied the helper still runs and prints the one-line L3
+context, but the main deliverable (`ip route get`) is skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from typing import Any
+
+from network_inventory import _load_api_class, _parse_l2_inventory, _resolve_devices
+
+
+# Route-get lines look like:
+#   10.200.0.2 via 10.1.1.1 dev eth0 src 10.1.1.10 uid 0
+# We extract the next-hop "via" and the egress "dev" so the neighbor state
+# for the next-hop can be looked up without re-parsing elsewhere.
+ROUTE_GET_VIA_RE = re.compile(r"\bvia\s+(\S+)")
+ROUTE_GET_DEV_RE = re.compile(r"\bdev\s+(\S+)")
+ROUTE_GET_SRC_RE = re.compile(r"\bsrc\s+(\S+)")
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _pick_target(api: Any, target_ip: str | None, target_device: str | None) -> str | None:
+    if target_ip:
+        return target_ip
+    if target_device:
+        try:
+            return api.get_host_ip(target_device)
+        except Exception:  # pragma: no cover - depends on live lab state
+            return None
+    return None
+
+
+def _parse_route_get(raw: str) -> dict[str, str]:
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("RTNETLINK") or stripped.startswith("cache"):
+            continue
+        record: dict[str, str] = {"raw": stripped}
+        via = ROUTE_GET_VIA_RE.search(stripped)
+        dev = ROUTE_GET_DEV_RE.search(stripped)
+        src = ROUTE_GET_SRC_RE.search(stripped)
+        if via:
+            record["via"] = via.group(1)
+        if dev:
+            record["dev"] = dev.group(1)
+        if src:
+            record["src"] = src.group(1)
+        return record
+    return {}
+
+
+def _neighbor_state_for(api: Any, device: str, next_hop: str) -> dict[str, str] | None:
+    raw, error = _safe_exec(api, device, f"ip neigh show to {next_hop}")
+    if error or not raw.strip():
+        return None
+    parts = raw.strip().split()
+    if not parts:
+        return None
+    entry = {"raw": raw.strip()}
+    if "lladdr" in parts:
+        try:
+            entry["lladdr"] = parts[parts.index("lladdr") + 1]
+        except (ValueError, IndexError):
+            pass
+    if parts[-1].isupper() and parts[-1].replace("_", "").isalpha():
+        entry["state"] = parts[-1]
+    return entry
+
+
+def _l3_context(api: Any, device: str) -> dict[str, Any]:
+    """Compact one-line-per-host L3 context — NOT a full state dump."""
+    try:
+        interfaces = _parse_l2_inventory(api, device, include_loopback=False, include_bridges=False)
+    except Exception as exc:  # pragma: no cover - depends on live lab state
+        return {"error": str(exc), "ipv4_present": None, "default_present": None, "resolver_count": None}
+
+    ipv4_present = any(interface.get("ipv4") for interface in interfaces)
+    route_raw, route_error = _safe_exec(api, device, "ip route")
+    default_present = bool(
+        route_raw and any(line.strip().startswith("default ") for line in route_raw.splitlines())
+    ) if not route_error else None
+    resolv_raw, resolv_error = _safe_exec(api, device, "cat /etc/resolv.conf 2>/dev/null")
+    resolver_count = None
+    if not resolv_error:
+        resolver_count = sum(
+            1 for line in resolv_raw.splitlines() if line.strip().startswith("nameserver ")
+        )
+    return {
+        "ipv4_present": ipv4_present,
+        "default_present": default_present,
+        "resolver_count": resolver_count,
+    }
+
+
+def _device_snapshot(api: Any, device: str, target: str | None) -> dict[str, Any]:
+    context = _l3_context(api, device)
+    route_get: dict[str, Any] = {}
+    neighbor: dict[str, str] | None = None
+
+    if target:
+        raw, error = _safe_exec(api, device, f"ip route get {target}")
+        if error:
+            route_get = {"error": error}
+        else:
+            parsed = _parse_route_get(raw)
+            route_get = {"raw": raw.strip(), **parsed}
+            if parsed.get("via"):
+                neighbor = _neighbor_state_for(api, device, parsed["via"])
+
+    flags: list[str] = []
+    if context.get("ipv4_present") is False:
+        flags.append("no_ipv4_address")
+    if context.get("default_present") is False:
+        flags.append("no_default_route")
+    if target and route_get.get("error"):
+        flags.append("route_get_failed")
+    if neighbor and neighbor.get("state") in {"FAILED", "INCOMPLETE"}:
+        flags.append(f"next_hop_state_{neighbor['state'].lower()}")
+
+    return {
+        "device": device,
+        "context": context,
+        "target": target,
+        "route_get": route_get,
+        "next_hop_neighbor": neighbor,
+        "flags": flags,
+    }
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("=== HOST PATH SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Target: {payload['target'] or '(none — route-get skipped; run infra_sweep for L3 state)'}")
+    lines.append("")
+    for item in payload["devices"]:
+        ctx = item["context"]
+        ipv4 = "yes" if ctx.get("ipv4_present") else ("no" if ctx.get("ipv4_present") is False else "?")
+        default = "yes" if ctx.get("default_present") else ("no" if ctx.get("default_present") is False else "?")
+        resolver_count = ctx.get("resolver_count")
+        resolvers = str(resolver_count) if resolver_count is not None else "?"
+        lines.append(item["device"])
+        lines.append(f"  L3 context: ipv4={ipv4} default_route={default} resolvers={resolvers}")
+        if item["target"]:
+            rg = item["route_get"]
+            if rg.get("error"):
+                lines.append(f"  Route to {item['target']}: ERROR — {rg['error']}")
+            elif rg:
+                via = rg.get("via", "(direct)")
+                dev = rg.get("dev", "?")
+                src = rg.get("src", "?")
+                lines.append(f"  Route to {item['target']}: via={via} dev={dev} src={src}")
+                lines.append(f"    raw: {rg.get('raw', '')}")
+            if item["next_hop_neighbor"]:
+                n = item["next_hop_neighbor"]
+                lines.append(
+                    f"  Next-hop neighbor: lladdr={n.get('lladdr', '(none)')} state={n.get('state', '?')}"
+                )
+        lines.append(f"  Flags: {', '.join(item['flags']) if item['flags'] else 'none'}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Route-selection drill-down (ip route get) for one or more hosts."
+    )
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("device_args", nargs="*", help="Device names to scan.")
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=["hosts", "routers", "switches", "servers", "bmv2_switches", "ovs_switches", "sdn_controllers", "all"],
+        dest="groups",
+    )
+    parser.add_argument("--target-ip")
+    parser.add_argument("--target-device")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    if args.device_args:
+        if args.devices:
+            parser.error("Use positional devices or --device, not both.")
+        args.devices = list(args.device_args)
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    groups = args.groups if args.groups else ([] if args.devices else ["hosts"])
+    devices = _resolve_devices(api, args.devices, groups, expand_neighbors=False)
+    target = _pick_target(api, args.target_ip, args.target_device)
+    payload = {
+        "lab_name": api.lab.name,
+        "target": target,
+        "devices": [_device_snapshot(api, device, target) for device in devices],
+    }
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/http_client_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/http_client_snapshot.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python
+"""
+Compact HTTP client snapshot helper.
+
+This catches host-selective HTTP failures that stay invisible when the agent
+tests only one healthy endpoint. It scans a selected device set (`hosts` by
+default), runs lightweight curl canaries to one hostname or URL, groups devices
+by HTTP outcome, and highlights outlier clients. When called without an
+explicit target, it prefers live published service hostnames over direct IPs so
+the sweep can still surface DNS-driven HTTP breakage.
+
+Primary use cases:
+- `http_acl_block`
+- host-selective service failure with clean reachability
+- proving "most hosts succeed, this host fails" before deeper DNS/LB checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from statistics import mean
+from typing import Any
+
+from network_inventory import _lab_groups, _load_api_class, _resolve_devices
+
+
+IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+ZONE_A_RECORD_RE = re.compile(r"^([A-Za-z0-9_-]+|@)\s+IN\s+A\s+((?:\d{1,3}\.){3}\d{1,3})\s*$")
+ZONE_BLOCK_RE = re.compile(r'zone\s+"([^"]+)"\s+IN\s*\{.*?file\s+"([^"]+)";', re.IGNORECASE | re.DOTALL)
+CURL_FIELD_RE = re.compile(
+    r"(http_code|remote_ip|namelookup|connect|appconnect|pretransfer|starttransfer|total):([^,\s]*)"
+)
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _rich_curl_command(url: str, times: int, connect_timeout: int, max_time: int) -> str:
+    return (
+        f"for i in $(seq 1 {times}); do "
+        f"curl -sS --connect-timeout {connect_timeout} --max-time {max_time} "
+        f"-o /dev/null "
+        f"-w 'http_code:%{{http_code}} remote_ip:%{{remote_ip}} namelookup:%{{time_namelookup}} "
+        f"connect:%{{time_connect}} starttransfer:%{{time_starttransfer}} total:%{{time_total}}\\n' "
+        f"'{url}' || echo 'curl_failed'; "
+        f"done"
+    )
+
+
+def _timing_curl_command(url: str, times: int, connect_timeout: int, max_time: int) -> str:
+    return (
+        f"for i in $(seq 1 {times}); do "
+        f"curl -sS --connect-timeout {connect_timeout} --max-time {max_time} "
+        f"-o /dev/null "
+        f"-w 'namelookup:%{{time_namelookup}}, connect:%{{time_connect}}, "
+        f"appconnect:%{{time_appconnect}}, pretransfer:%{{time_pretransfer}}, "
+        f"starttransfer:%{{time_starttransfer}}, total:%{{time_total}}\\n' "
+        f"'{url}' || echo 'curl_failed'; "
+        f"done"
+    )
+
+
+def _curl_web_test_raw(
+    api: Any,
+    device: str,
+    url: str,
+    times: int,
+    connect_timeout: int,
+    max_time: int,
+) -> tuple[str, str | None, str]:
+    # Match Kathara's native curl_web_test behavior whenever the caller keeps
+    # its default timeouts; otherwise fall back to an equivalent shell probe.
+    if connect_timeout == 5 and max_time == 10 and hasattr(api, "curl_web_test"):
+        try:
+            output = api.curl_web_test(host_name=device, url=url, times=times)
+        except Exception:
+            output = ""
+        if output and not _command_failed(output):
+            return output, None, "curl_web_test"
+        if output and _command_failed(output):
+            return output, output, "curl_web_test"
+
+    raw, error = _safe_exec(api, device, _timing_curl_command(url, times, connect_timeout, max_time))
+    return raw, error, "exec_shell"
+
+
+def _default_web_service_devices(api: Any) -> list[str]:
+    inventory = _lab_groups(api)
+    devices: list[str] = []
+    devices.extend(sorted(inventory["servers"].get("web", [])))
+    devices.extend(sorted(inventory["servers"].get("load_balancer", [])))
+    return list(dict.fromkeys(devices))
+
+
+def _device_http_url(api: Any, device: str) -> str | None:
+    try:
+        ip = api.get_host_ip(device, with_prefix=False)
+    except TypeError:
+        ip = api.get_host_ip(device)
+    except Exception:
+        return None
+    if not ip:
+        return None
+    if "/" in ip:
+        ip = ip.split("/", 1)[0]
+    return f"http://{ip}/"
+
+
+def _device_ip(api: Any, device: str) -> str | None:
+    try:
+        ip = api.get_host_ip(device, with_prefix=False)
+    except TypeError:
+        ip = api.get_host_ip(device)
+    except Exception:
+        return None
+    if not ip:
+        return None
+    return ip.split("/", 1)[0]
+
+
+def _hostname_from_url(url: str) -> str | None:
+    target = url
+    if "://" in target:
+        target = target.split("://", 1)[1]
+    host = target.split("/", 1)[0].split(":", 1)[0].strip()
+    return host or None
+
+
+def _parse_zone_a_records(raw: str) -> list[tuple[str, str]]:
+    records: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        stripped = line.split(";", 1)[0].strip()
+        if not stripped:
+            continue
+        match = ZONE_A_RECORD_RE.match(stripped)
+        if match:
+            records.append((match.group(1), match.group(2)))
+    return records
+
+
+def _reverse_zone(zone: str) -> bool:
+    normalized = zone.lower().rstrip(".")
+    return normalized.endswith(".in-addr.arpa") or normalized.endswith(".ip6.arpa")
+
+
+_BIND_DEFAULT_ZONES = frozenset({"0", "127", "255", "empty", "root"})
+
+
+def _zone_from_path(path: str) -> str | None:
+    filename = path.rsplit("/", 1)[-1].strip()
+    if not filename or filename.endswith(".bak"):
+        return None
+    if filename.startswith("db."):
+        zone = filename[3:]
+    elif filename.endswith(".zone"):
+        zone = filename[:-5]
+    else:
+        return None
+    if not zone or _reverse_zone(zone):
+        return None
+    # Skip bind9 default empty-zone files (db.0, db.127, db.255, db.empty,
+    # db.root). They generate bogus hostnames in the inferred-hostname path.
+    if zone in _BIND_DEFAULT_ZONES:
+        return None
+    return zone
+
+
+def _bind_zone_sources(api: Any, dns_device: str) -> list[tuple[str, str]]:
+    candidates: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for config_path in (
+        "/etc/bind/named.conf",
+        "/etc/bind/named.conf.local",
+        "/etc/bind/named.conf.default-zones",
+    ):
+        config_raw, config_error = _safe_exec(api, dns_device, f"cat {config_path} 2>/dev/null")
+        if config_error:
+            continue
+        for zone, path in ZONE_BLOCK_RE.findall(config_raw):
+            normalized_zone = zone.strip().rstrip(".")
+            normalized_path = path.strip()
+            if not normalized_zone or not normalized_path or _reverse_zone(normalized_zone):
+                continue
+            key = (normalized_zone, normalized_path)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(key)
+
+    file_list_raw, file_list_error = _safe_exec(api, dns_device, "find /etc/bind -maxdepth 2 -type f 2>/dev/null")
+    if file_list_error:
+        return candidates
+
+    for raw_path in file_list_raw.splitlines():
+        path = raw_path.strip()
+        if not path:
+            continue
+        zone = _zone_from_path(path)
+        if not zone:
+            continue
+        key = (zone, path)
+        if key not in seen:
+            seen.add(key)
+            candidates.append(key)
+
+    return candidates
+
+
+def _expected_service_ips(api: Any) -> set[str]:
+    addresses: set[str] = set()
+    for device in _default_web_service_devices(api):
+        if ip := _device_ip(api, device):
+            addresses.add(ip)
+    return addresses
+
+
+def _inferred_service_hostnames(api: Any, zones: list[str]) -> list[str]:
+    hostnames: list[str] = []
+    service_devices = _default_web_service_devices(api)
+
+    for zone in zones:
+        normalized_zone = zone.strip().rstrip(".")
+        if not normalized_zone or _reverse_zone(normalized_zone):
+            continue
+        for device in service_devices:
+            device_l = device.lower()
+            if "load_balancer" in device_l:
+                hostname = f"web99.{normalized_zone}"
+            else:
+                web_index = _web_index_from_device(device_l)
+                if web_index is None:
+                    continue
+                hostname = f"web{web_index}.{normalized_zone}"
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+
+    return hostnames
+
+
+def _published_hostnames(api: Any) -> list[str]:
+    inventory = _lab_groups(api)
+    dns_devices = sorted(inventory["servers"].get("dns", []))
+    hostnames: list[str] = []
+    inferred_hostnames: list[str] = []
+
+    for dns_device in dns_devices:
+        zone_sources = _bind_zone_sources(api, dns_device)
+        zone_names = [zone for zone, _path in zone_sources]
+        for hostname in _inferred_service_hostnames(api, zone_names):
+            if hostname not in inferred_hostnames:
+                inferred_hostnames.append(hostname)
+
+        for zone, path in zone_sources:
+            zone_raw, zone_error = _safe_exec(api, dns_device, f"cat {path} 2>/dev/null")
+            if zone_error:
+                continue
+            for label, _ip in _parse_zone_a_records(zone_raw):
+                lowered = label.lower()
+                if label == "@" or lowered.startswith("ns") or not lowered.startswith("web"):
+                    continue
+                hostname = f"{label}.{zone}"
+                if hostname not in hostnames:
+                    hostnames.append(hostname)
+
+    if hostnames:
+        for hostname in inferred_hostnames:
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+        return hostnames
+    return inferred_hostnames
+
+
+def _hostname_tokens(hostname: str) -> tuple[str, list[str]]:
+    label, _, zone = hostname.lower().partition(".")
+    zone_tokens = [token for token in re.split(r"[^a-z0-9]+", zone) if token]
+    return label, zone_tokens
+
+
+def _web_index_from_label(label: str) -> str | None:
+    match = re.match(r"web(\d+)", label)
+    return match.group(1) if match else None
+
+
+def _web_index_from_device(device: str) -> str | None:
+    for pattern in (r"web_server_(\d+)", r"webserver(\d+)", r"web_(\d+)"):
+        match = re.search(pattern, device.lower())
+        if match:
+            return match.group(1)
+    return None
+
+
+def _device_matches_hostname(device: str, hostname: str) -> bool:
+    device_l = device.lower()
+    label, zone_tokens = _hostname_tokens(hostname)
+    label_index = _web_index_from_label(label)
+
+    if "load_balancer" in device_l:
+        return label.startswith("web") and label.endswith("99")
+
+    if "web" not in label or "web" not in device_l:
+        return False
+
+    device_index = _web_index_from_device(device_l)
+    if label_index and device_index and label_index != device_index:
+        return False
+    if label_index and not device_index:
+        return False
+
+    scoped_zone_tokens = [token for token in zone_tokens if token.startswith("pod") or any(ch.isdigit() for ch in token)]
+    if scoped_zone_tokens and not all(token in device_l for token in scoped_zone_tokens):
+        return False
+
+    return True
+
+
+def _expected_addresses_by_hostname(api: Any, hostnames: list[str]) -> dict[str, str]:
+    service_devices = _default_web_service_devices(api)
+    ip_by_device = {device: ip for device in service_devices if (ip := _device_ip(api, device))}
+    expected: dict[str, str] = {}
+
+    for hostname in hostnames:
+        candidates = [device for device in service_devices if _device_matches_hostname(device, hostname)]
+        candidates = [device for device in candidates if device in ip_by_device]
+        if len(candidates) == 1:
+            expected[hostname] = ip_by_device[candidates[0]]
+
+    return expected
+
+
+def _target_specs(api: Any, hostname: str | None, url: str | None) -> list[dict[str, str | None]]:
+    if url:
+        url_hostname = _hostname_from_url(url)
+        expected_remote_ip = None
+        if url_hostname and not IP_RE.fullmatch(url_hostname):
+            expected_remote_ip = _expected_addresses_by_hostname(api, [url_hostname]).get(url_hostname)
+        return [{"label": url, "url": url, "expected_remote_ip": expected_remote_ip}]
+    if hostname:
+        expected_by_hostname = _expected_addresses_by_hostname(api, [hostname])
+        return [{
+            "label": hostname,
+            "url": f"http://{hostname}/",
+            "expected_remote_ip": expected_by_hostname.get(hostname),
+        }]
+
+    published_hostnames = _published_hostnames(api)
+    if published_hostnames:
+        expected_by_hostname = _expected_addresses_by_hostname(api, published_hostnames)
+        return [
+            {
+                "label": service_hostname,
+                "url": f"http://{service_hostname}/",
+                "expected_remote_ip": expected_by_hostname.get(service_hostname),
+            }
+            for service_hostname in published_hostnames
+        ]
+
+    specs = []
+    for device in _default_web_service_devices(api):
+        device_url = _device_http_url(api, device)
+        if not device_url:
+            continue
+        specs.append({"label": device, "url": device_url, "expected_remote_ip": _device_ip(api, device)})
+    return specs
+
+
+def _parse_curl_samples(raw: str) -> tuple[list[dict[str, Any]], list[str]]:
+    samples: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "curl_failed" or stripped.startswith("curl:"):
+            errors.append(stripped)
+            continue
+        fields = dict(CURL_FIELD_RE.findall(stripped))
+        if not fields:
+            errors.append(stripped)
+            continue
+        sample: dict[str, Any] = {"raw": stripped}
+        for key, value in fields.items():
+            if key == "http_code":
+                sample[key] = value
+            else:
+                try:
+                    sample[key] = float(value)
+                except ValueError:
+                    sample[key] = value
+        samples.append(sample)
+    return samples, errors
+
+
+def _http_summary(raw: str) -> dict[str, Any]:
+    samples, errors = _parse_curl_samples(raw)
+    totals = [sample["total"] for sample in samples if isinstance(sample.get("total"), float)]
+    connects = [sample["connect"] for sample in samples if isinstance(sample.get("connect"), float)]
+    name_lookups = [sample["namelookup"] for sample in samples if isinstance(sample.get("namelookup"), float)]
+    starttransfers = [sample["starttransfer"] for sample in samples if isinstance(sample.get("starttransfer"), float)]
+    codes = sorted({sample["http_code"] for sample in samples if sample.get("http_code")})
+    remote_ips = sorted({sample["remote_ip"] for sample in samples if sample.get("remote_ip")})
+    return {
+        "samples": samples,
+        "errors": errors,
+        "http_codes": codes,
+        "remote_ips": remote_ips,
+        "avg_namelookup": round(mean(name_lookups), 3) if name_lookups else None,
+        "avg_connect": round(mean(connects), 3) if connects else None,
+        "avg_starttransfer": round(mean(starttransfers), 3) if starttransfers else None,
+        "avg_total": round(mean(totals), 3) if totals else None,
+    }
+
+
+def _http_signature(summary: dict[str, Any]) -> str:
+    code_text = ",".join(summary["http_codes"]) if summary["http_codes"] else "(none)"
+    if not summary["samples"]:
+        return "http_problem:no_samples"
+    if any(code == "000" or not code.startswith(("2", "3")) for code in summary["http_codes"]):
+        return f"http_non_ok:{code_text}"
+    if summary["errors"]:
+        return f"http_problem:{code_text}"
+    return f"http_ok:{code_text}"
+
+
+def _client_snapshot(
+    api: Any,
+    device: str,
+    url: str,
+    expected_remote_ip: str | None,
+    expected_service_ips: set[str],
+    times: int,
+    connect_timeout: int,
+    max_time: int,
+) -> dict[str, Any]:
+    timing_raw, timing_error, probe_method = _curl_web_test_raw(
+        api, device, url, times, connect_timeout, max_time
+    )
+    timing_summary = _http_summary(timing_raw) if not timing_error else {
+        "samples": [],
+        "errors": [timing_error],
+        "http_codes": [],
+        "remote_ips": [],
+        "avg_namelookup": None,
+        "avg_connect": None,
+        "avg_starttransfer": None,
+        "avg_total": None,
+    }
+    identity_raw, identity_error = _safe_exec(api, device, _rich_curl_command(url, 1, connect_timeout, max_time))
+    identity_summary = _http_summary(identity_raw) if not identity_error else {
+        "samples": [],
+        "errors": [identity_error],
+        "http_codes": [],
+        "remote_ips": [],
+        "avg_namelookup": None,
+        "avg_connect": None,
+        "avg_starttransfer": None,
+        "avg_total": None,
+    }
+    summary = {
+        **timing_summary,
+        "http_codes": identity_summary["http_codes"],
+        "remote_ips": identity_summary["remote_ips"],
+        "identity_errors": identity_summary["errors"],
+    }
+    flags: list[str] = []
+    if timing_error or not summary["samples"]:
+        flags.append("http_problem")
+    elif summary["http_codes"] and any(code == "000" or not code.startswith(("2", "3")) for code in summary["http_codes"]):
+        flags.append("http_non_ok")
+    elif identity_error:
+        flags.append("http_identity_probe_failed")
+    if expected_remote_ip and summary["remote_ips"] and any(ip != expected_remote_ip for ip in summary["remote_ips"]):
+        flags.append("wrong_remote_ip")
+    elif not expected_remote_ip and summary["remote_ips"] and expected_service_ips and any(ip not in expected_service_ips for ip in summary["remote_ips"]):
+        flags.append("unexpected_service_remote_ip")
+    return {
+        "device": device,
+        "url": url,
+        "expected_remote_ip": expected_remote_ip,
+        "probe_method": probe_method,
+        "signature": _http_signature(summary),
+        "flags": flags,
+        **summary,
+    }
+
+
+def _text_summary(payload: dict[str, Any], healthy_preview: int) -> str:
+    lines = []
+    lines.append("=== HTTP CLIENT SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Devices scanned: {len(payload['devices_scanned'])}")
+    lines.append(f"Targets scanned: {len(payload['targets'])}")
+    lines.append("")
+
+    for index, target in enumerate(payload["targets"]):
+        lines.append(f"Target: {target['label']}")
+        lines.append(f"URL: {target['url']}")
+        if target["probe_method"]:
+            lines.append(f"Timing sweep: {target['probe_method']}")
+        if target["expected_remote_ip"]:
+            lines.append(f"Expected remote IP: {target['expected_remote_ip']}")
+        if target["expected_ok_signature"]:
+            lines.append(
+                f"Expected healthy profile: {target['expected_ok_signature']} "
+                f"({target['expected_ok_count']}/{len(payload['devices_scanned'])} devices)"
+            )
+        lines.append("")
+
+        # Cross-client outcome grouping is produced by service_snapshot's
+        # triage view; this script does not re-emit it. Our unique contribution
+        # is the rich per-host timing (avg_name/avg_connect/avg_ttfb below)
+        # and the expected-healthy-profile majority inference above.
+
+        if target["suspect_hosts"]:
+            lines.append("")
+            lines.append("Suspect hosts:")
+            for record in target["records"]:
+                if record["device"] not in target["suspect_hosts"]:
+                    continue
+                code_text = ", ".join(record["http_codes"]) if record["http_codes"] else "(none)"
+                remote_text = ", ".join(record["remote_ips"]) if record["remote_ips"] else "(none)"
+                name_text = f"{record['avg_namelookup']:.3f}s" if isinstance(record["avg_namelookup"], float) else "(none)"
+                connect_text = f"{record['avg_connect']:.3f}s" if isinstance(record["avg_connect"], float) else "(none)"
+                starttransfer_text = (
+                    f"{record['avg_starttransfer']:.3f}s"
+                    if isinstance(record["avg_starttransfer"], float)
+                    else "(none)"
+                )
+                avg_text = f"{record['avg_total']:.3f}s" if isinstance(record["avg_total"], float) else "(none)"
+                flags_text = ", ".join(record["flags"]) if record["flags"] else "none"
+                error_text = "; ".join((record["errors"] + record["identity_errors"])[:2]) if (record["errors"] or record["identity_errors"]) else "(none)"
+                lines.append(
+                    f"- {record['device']}: codes={code_text} remote_ips={remote_text} "
+                    f"avg_name={name_text} avg_connect={connect_text} avg_ttfb={starttransfer_text} avg_total={avg_text} "
+                    f"flags={flags_text} errors={error_text}"
+                )
+        else:
+            lines.append("")
+            lines.append("Suspect hosts: none")
+
+        if target["expected_ok_signature"]:
+            healthy_hosts = target["outcome_groups"].get(target["expected_ok_signature"], [])
+            if healthy_hosts:
+                lines.append("")
+                lines.append("Healthy sample:")
+                for device in healthy_hosts[:healthy_preview]:
+                    lines.append(f"- {device}")
+
+        if index != len(payload["targets"]) - 1:
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact HTTP client snapshot helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("target", nargs="?", help="Optional hostname or full URL shortcut.")
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=["hosts", "routers", "switches", "servers", "bmv2_switches", "ovs_switches", "sdn_controllers", "all"],
+        dest="groups",
+    )
+    parser.add_argument("--hostname")
+    parser.add_argument("--url")
+    parser.add_argument("--times", type=int, default=2)
+    parser.add_argument("--connect-timeout", type=int, default=5)
+    parser.add_argument("--max-time", type=int, default=10)
+    parser.add_argument("--healthy-preview", type=int, default=6)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    if args.target:
+        if args.hostname or args.url:
+            parser.error("Use either the positional target or --hostname/--url, not both.")
+        if "://" in args.target:
+            args.url = args.target
+        else:
+            args.hostname = args.target
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    target_specs = _target_specs(api, args.hostname, args.url)
+    if not target_specs:
+        parser.error("Provide a hostname or URL, or ensure the topology exposes web/load_balancer devices.")
+    devices = _resolve_devices(api, args.devices, args.groups or ["hosts"], expand_neighbors=False)
+    if not devices:
+        parser.error("No client devices resolved for the requested scope.")
+    expected_service_ips = _expected_service_ips(api)
+
+    target_payloads = []
+    for spec in target_specs:
+        records = [
+            _client_snapshot(
+                api,
+                device,
+                str(spec["url"]),
+                spec.get("expected_remote_ip"),
+                expected_service_ips,
+                args.times,
+                args.connect_timeout,
+                args.max_time,
+            )
+            for device in devices
+        ]
+
+        expected_ok_signature = None
+        expected_ok_count = 0
+        ok_counter = Counter(record["signature"] for record in records if record["signature"].startswith("http_ok:"))
+        if ok_counter:
+            expected_ok_signature, expected_ok_count = ok_counter.most_common(1)[0]
+
+        suspect_hosts: list[str] = []
+        for record in records:
+            if record["flags"]:
+                suspect_hosts.append(record["device"])
+                continue
+            if expected_ok_signature and record["signature"] != expected_ok_signature:
+                record["flags"].append("different_http_profile")
+                suspect_hosts.append(record["device"])
+
+        outcome_groups: dict[str, list[str]] = defaultdict(list)
+        for record in records:
+            outcome_groups[record["signature"]].append(record["device"])
+
+        target_payloads.append(
+            {
+                "label": spec["label"],
+                "url": spec["url"],
+                "probe_method": records[0]["probe_method"] if records else None,
+                "expected_remote_ip": spec.get("expected_remote_ip"),
+                "expected_ok_signature": expected_ok_signature,
+                "expected_ok_count": expected_ok_count,
+                "suspect_hosts": sorted(set(suspect_hosts)),
+                "outcome_groups": {key: sorted(value) for key, value in sorted(outcome_groups.items())},
+                "records": records,
+            }
+        )
+
+    payload = {
+        "lab_name": api.lab.name,
+        "devices_scanned": devices,
+        "targets": target_payloads,
+    }
+
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload, healthy_preview=max(args.healthy_preview, 0)), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/infra_sweep.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/infra_sweep.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python
+"""
+Universal infrastructure sweep: one pass across every device.
+
+A single-pass safety net for fault classes that would otherwise need
+multiple separate checks:
+- nft list ruleset      -> catch ACL/firewall drops (http_acl_block, icmp_acl_block,
+                           dns_port_blocked, ospf_acl_block, link_fragmentation_disabled)
+- ip -br addr / ip route -> catch missing IPs, missing default routes, wrong netmask,
+                           wrong gateway on any host
+- arp -n                 -> catch wrong gateway lladdr values (arp_cache_poisoning)
+- cat /etc/resolv.conf   -> catch resolver-mismatch (host_incorrect_dns)
+
+The helper is intentionally cheap: it only surfaces flagged devices by default.
+Use `--show-clean` to print the unflagged rows too.
+
+The fault-family skills still own the final classification. This script exists
+so the diagnosis methodology cannot miss a symptom by accidentally skipping the
+ACL or host-config sweep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+from typing import Any
+
+from network_inventory import _load_api_class, _resolve_devices
+
+
+DEFAULT_GROUPS = [
+    "hosts",
+    "routers",
+    "switches",
+    "servers",
+    "bmv2_switches",
+    "ovs_switches",
+    "sdn_controllers",
+    "other_devices",
+]
+
+# Drop verdicts that point at a specific fault family. Order matters:
+# the first match wins when several keywords appear in the same ruleset line.
+ACL_FINGERPRINTS: list[tuple[str, re.Pattern[str], str]] = [
+    ("arp_acl_block", re.compile(r"table\s+arp\s+filter", re.IGNORECASE), "arp filter table with drop rules"),
+    ("ospf_acl_block", re.compile(r"(\bip\s+protocol\s+ospf\b|\bip\s+protocol\s+89\b|\bproto\s+89\b)", re.IGNORECASE), "OSPF protocol 89 filter"),
+    ("bgp_acl_block", re.compile(r"\btcp\s+dport\s+179\b", re.IGNORECASE), "TCP port 179 (BGP) filter"),
+    ("http_acl_block", re.compile(r"\btcp\s+dport\s+80\b", re.IGNORECASE), "TCP port 80 filter"),
+    ("dns_port_blocked", re.compile(r"\b(tcp|udp)\s+dport\s+53\b", re.IGNORECASE), "port 53 (DNS) filter"),
+    ("icmp_acl_block", re.compile(r"\b(icmp\s+type|ip\s+protocol\s+icmp|ip\s+protocol\s+1)\b", re.IGNORECASE), "ICMP filter"),
+    ("link_fragmentation_disabled", re.compile(r"(-m\s+length|\bmeta\s+length\b|\bip\s+length\b)", re.IGNORECASE), "packet-length filter"),
+]
+
+# Lines that always appear from Docker's default runtime and must not be flagged.
+DOCKER_NOISE = re.compile(r"DOCKER_OUTPUT|DOCKER_POSTROUTING|127\.0\.0\.11", re.IGNORECASE)
+
+DROP_RE = re.compile(r"\b(drop|reject)\b", re.IGNORECASE)
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if isinstance(output, list):
+        output = "\n".join(output)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _parse_nft_rules(raw: str) -> list[dict[str, Any]]:
+    """Return one record per rule line that contains drop/reject and is not Docker NAT noise."""
+    hits: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not DROP_RE.search(stripped):
+            continue
+        if DOCKER_NOISE.search(stripped):
+            continue
+        classification = "drop_rule"
+        reason = "generic drop/reject rule"
+        for name, pattern, human in ACL_FINGERPRINTS:
+            if pattern.search(stripped):
+                classification = name
+                reason = human
+                break
+        hits.append({"rule": stripped, "classification": classification, "reason": reason})
+    return hits
+
+
+def _parse_ip_addr(raw: str) -> list[dict[str, Any]]:
+    """Parse `ip -br addr` output. One row per interface with IPv4s."""
+    entries = []
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        ifname, state, *addrs = parts
+        if ifname == "lo":
+            continue
+        ipv4 = [a for a in addrs if "." in a and ":" not in a]
+        entries.append({"ifname": ifname, "state": state, "ipv4": ipv4})
+    return entries
+
+
+def _parse_ip_route(raw: str) -> dict[str, Any]:
+    defaults = []
+    routes = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        routes.append(stripped)
+        if stripped.startswith("default"):
+            # default via 10.1.1.1 dev eth0
+            parts = stripped.split()
+            via = parts[parts.index("via") + 1] if "via" in parts else ""
+            dev = parts[parts.index("dev") + 1] if "dev" in parts else ""
+            defaults.append({"raw": stripped, "via": via, "dev": dev})
+    return {"defaults": defaults, "route_count": len(routes)}
+
+
+MAC_RE = re.compile(r"^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
+# A static (manually-set) ARP entry on a host is the durable, generic
+# fingerprint of ARP cache tampering: `arp -s` shows "CM" in `arp -n` output
+# and "PERMANENT" in `ip neigh show`. Real OSes do not auto-create static
+# entries — anything that sets one did so deliberately, which on an end host
+# is almost always an attack or misconfiguration worth surfacing. We do NOT
+# blacklist specific "dummy MAC" values (e.g. 00:11:22:33:44:55) because
+# that just over-fits to one injector; the static-entry signal catches the
+# fault regardless of which MAC the attacker chose.
+STATIC_ARP_FLAGS = frozenset({"CM", "PM", "PERMANENT"})
+
+
+def _looks_fabricated(mac: str) -> str | None:
+    """Return a short reason if the MAC looks fabricated, else None.
+
+    Generic heuristics (no specific value blacklist):
+    - all zero / all FF / all same byte
+    - sequential ascending bytes (00:11:22:33:44:55, 01:02:03:04:05:06, ...)
+    These patterns never come out of a real NIC's burned-in address.
+    """
+    if not MAC_RE.match(mac):
+        return None
+    try:
+        bytes_ = [int(b, 16) for b in mac.split(":")]
+    except ValueError:
+        return None
+    if all(b == 0 for b in bytes_):
+        return "all-zero MAC"
+    if all(b == 0xFF for b in bytes_):
+        return "broadcast MAC in unicast position"
+    if len(set(bytes_)) == 1:
+        return f"all-same-byte MAC ({mac.split(':')[0]})"
+    # Ascending-by-N pattern: e.g. 00:11:22:33:44:55 (delta 0x11)
+    deltas = [(bytes_[i + 1] - bytes_[i]) & 0xFF for i in range(5)]
+    if len(set(deltas)) == 1 and deltas[0] in (0x01, 0x10, 0x11):
+        return f"sequential-byte pattern (delta {deltas[0]:#04x})"
+    return None
+
+
+def _parse_arp(raw: str) -> list[dict[str, str]]:
+    """Parse ARP / neighbor table output.
+
+    Supports both `ip neigh show` (preferred, modern) and legacy `arp -n`:
+      - `ip neigh show`: "<ip> dev <iface> lladdr <mac> <state>"
+      - `arp -n`:        "<ip>  ether  <mac>  <flags> <iface>" (flags optional)
+    """
+    entries: list[dict[str, str]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("Address"):
+            continue
+        tokens = stripped.split()
+        if not tokens:
+            continue
+
+        ip = tokens[0]
+        iface = ""
+        mac = ""
+        flag = ""
+
+        if "lladdr" in tokens:
+            # `ip neigh show` format.
+            try:
+                lladdr_idx = tokens.index("lladdr")
+                mac = tokens[lladdr_idx + 1]
+            except (ValueError, IndexError):
+                mac = ""
+            if "dev" in tokens:
+                try:
+                    dev_idx = tokens.index("dev")
+                    iface = tokens[dev_idx + 1]
+                except (ValueError, IndexError):
+                    iface = ""
+            # Last token is usually the state word (REACHABLE / STALE / PERMANENT / ...).
+            tail = tokens[-1].upper()
+            if tail in {"PERMANENT", "NOARP", "REACHABLE", "STALE", "DELAY", "PROBE", "FAILED", "INCOMPLETE"}:
+                flag = tail
+        else:
+            # Legacy `arp -n` format. Find the MAC by pattern, take iface as
+            # last token, and any tokens between MAC and iface as flags.
+            mac_positions = [i for i, t in enumerate(tokens) if MAC_RE.match(t)]
+            if not mac_positions:
+                continue
+            mac_idx = mac_positions[0]
+            mac = tokens[mac_idx]
+            iface = tokens[-1]
+            middle = tokens[mac_idx + 1:-1]
+            if middle:
+                flag = middle[0]
+        if not mac:
+            continue
+        entries.append({"ip": ip, "mac": mac, "iface": iface, "flag": flag})
+    return entries
+
+
+def _parse_nameservers(raw: str) -> list[str]:
+    nameservers = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("nameserver "):
+            nameservers.append(stripped.split(None, 1)[1])
+    return nameservers
+
+
+# Conservative thresholds: Kathara idle labs should have 0 errors and <=1 carrier
+# transition per interface. We only flag sustained signal, not a single reset.
+LINK_FLAP_CARRIER_THRESHOLD = 2
+LINK_ERROR_THRESHOLD = 5
+
+
+def _parse_link_stats(raw: str) -> list[dict[str, Any]]:
+    """Parse `ip -j -s link show` JSON into compact per-interface records.
+
+    We only keep fields that carry flap / error signal: operstate, carrier
+    transitions, and rx/tx error/dropped counters. Non-physical interfaces
+    like `lo` are dropped because they do not carry flap semantics.
+    """
+    try:
+        data = json.loads(raw) if raw.strip() else []
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+
+    records: list[dict[str, Any]] = []
+    for link in data:
+        ifname = link.get("ifname")
+        if not ifname or ifname == "lo":
+            continue
+        stats = link.get("stats64") or {}
+        rx = stats.get("rx") or {}
+        tx = stats.get("tx") or {}
+        carrier = (
+            link.get("carrier_changes")
+            or link.get("link_info", {}).get("info_slave_data", {}).get("carrier_changes")
+            or tx.get("carrier_changes")
+            or 0
+        )
+        try:
+            carrier_int = int(carrier)
+        except (TypeError, ValueError):
+            carrier_int = 0
+        records.append(
+            {
+                "ifname": ifname,
+                "operstate": link.get("operstate"),
+                "carrier_changes": carrier_int,
+                "rx_errors": int(rx.get("errors") or 0),
+                "rx_dropped": int(rx.get("dropped") or 0),
+                "tx_errors": int(tx.get("errors") or 0),
+                "tx_dropped": int(tx.get("dropped") or 0),
+            }
+        )
+    return records
+
+
+def _link_stats_flags(records: list[dict[str, Any]]) -> list[str]:
+    flags: list[str] = []
+    for entry in records:
+        ifname = entry["ifname"]
+        if entry["carrier_changes"] >= LINK_FLAP_CARRIER_THRESHOLD:
+            flags.append(
+                f"link_flap_suspected: {ifname} carrier_changes={entry['carrier_changes']}"
+            )
+        if entry["rx_errors"] >= LINK_ERROR_THRESHOLD or entry["tx_errors"] >= LINK_ERROR_THRESHOLD:
+            flags.append(
+                f"link_errors: {ifname} rx_errors={entry['rx_errors']} tx_errors={entry['tx_errors']}"
+            )
+        if entry["rx_dropped"] >= LINK_ERROR_THRESHOLD or entry["tx_dropped"] >= LINK_ERROR_THRESHOLD:
+            flags.append(
+                f"link_drops: {ifname} rx_dropped={entry['rx_dropped']} tx_dropped={entry['tx_dropped']}"
+            )
+        if entry["operstate"] == "DOWN":
+            flags.append(f"interface_down: {ifname}")
+    return flags
+
+
+def _device_sweep(api: Any, device: str, role: str) -> dict[str, Any]:
+    # One compound shell call per device, delimited by markers so we do not pay
+    # four MCP round-trips for each host. Most devices expose all of these.
+    compound = (
+        "echo '===NFT==='; nft list ruleset 2>/dev/null || iptables-save 2>/dev/null; "
+        "echo '===ADDR==='; ip -br addr; "
+        "echo '===ROUTE==='; ip route; "
+        "echo '===ARP==='; ip neigh show 2>/dev/null || arp -n; "
+        "echo '===RESOLV==='; cat /etc/resolv.conf 2>/dev/null; "
+        "echo '===LINKSTATS==='; ip -j -s link show 2>/dev/null"
+    )
+    raw, error = _safe_exec(api, device, compound)
+    if error:
+        return {
+            "device": device,
+            "role": role,
+            "error": error,
+            "flags": [f"{device}: sweep command failed"],
+        }
+
+    sections = {}
+    current = None
+    for line in raw.splitlines():
+        if line.startswith("===") and line.endswith("==="):
+            current = line.strip("= ")
+            sections[current] = []
+            continue
+        if current is not None:
+            sections[current].append(line)
+    for key in ("NFT", "ADDR", "ROUTE", "ARP", "RESOLV", "LINKSTATS"):
+        sections.setdefault(key, [])
+
+    nft_hits = _parse_nft_rules("\n".join(sections["NFT"]))
+    interfaces = _parse_ip_addr("\n".join(sections["ADDR"]))
+    routes = _parse_ip_route("\n".join(sections["ROUTE"]))
+    arp_entries = _parse_arp("\n".join(sections["ARP"]))
+    nameservers = _parse_nameservers("\n".join(sections["RESOLV"]))
+    link_stats = _parse_link_stats("\n".join(sections["LINKSTATS"]))
+    link_stat_flags = _link_stats_flags(link_stats)
+
+    ipv4_present = any(iface["ipv4"] for iface in interfaces)
+    has_default = bool(routes["defaults"])
+
+    flags: list[str] = []
+    for hit in nft_hits:
+        flags.append(f"{hit['classification']}: {hit['reason']}")
+    flags.extend(link_stat_flags)
+
+    # ARP signals: a static / PERMANENT entry on a host (`arp -s ...`) is the
+    # generic fingerprint of cache tampering — real OSes never auto-create
+    # those. We additionally flag a MAC that looks fabricated by structural
+    # pattern (all-zero, all-same-byte, sequential bytes) — these patterns
+    # never come from a real NIC, regardless of which attacker injected them.
+    if role == "host":
+        for entry in arp_entries:
+            if entry.get("flag") in STATIC_ARP_FLAGS:
+                flags.append(
+                    f"static_arp_entry: {entry['ip']}={entry['mac']} (state={entry['flag']}) — manual `arp -s` suspected"
+                )
+        for entry in arp_entries:
+            reason = _looks_fabricated(entry.get("mac", ""))
+            if reason:
+                flags.append(
+                    f"fabricated_mac_in_arp: {entry['ip']}={entry['mac']} ({reason})"
+                )
+
+    if role == "host" and not ipv4_present:
+        flags.append("no_ipv4_address")
+    if role == "host" and not has_default:
+        flags.append("no_default_route")
+    # Hosts should have exactly one default route entry most of the time;
+    # multiple defaults via different gateways is a spoof/misconfig smell.
+    if role == "host" and len({r["via"] for r in routes["defaults"] if r["via"]}) > 1:
+        flags.append("multiple_default_gateways")
+
+    return {
+        "device": device,
+        "role": role,
+        "error": None,
+        "nft_hits": nft_hits,
+        "interfaces": interfaces,
+        "default_routes": routes["defaults"],
+        "route_count": routes["route_count"],
+        "arp": arp_entries,
+        "nameservers": nameservers,
+        "link_stats": link_stats,
+        "flags": flags,
+    }
+
+
+def _role_of(device: str, groups: dict[str, Any]) -> str:
+    if device in groups.get("hosts", []):
+        return "host"
+    if device in groups.get("routers", []):
+        return "router"
+    if device in groups.get("switches", []):
+        return "switch"
+    for role, members in (groups.get("servers") or {}).items():
+        if device in members:
+            return f"server:{role}"
+    return "other"
+
+
+def _cross_host_checks(host_rows: list[dict[str, Any]]) -> list[str]:
+    """Add cross-host flags: resolver divergence, ARP gateway lladdr divergence."""
+    findings: list[str] = []
+
+    # Resolver groups
+    resolver_to_hosts: dict[tuple[str, ...], list[str]] = {}
+    for row in host_rows:
+        key = tuple(sorted(row["nameservers"]))
+        resolver_to_hosts.setdefault(key, []).append(row["device"])
+    if len(resolver_to_hosts) > 1:
+        desc = "; ".join(
+            f"{list(k) or '(empty)'} -> {len(v)} hosts [{', '.join(v[:3])}]"
+            for k, v in resolver_to_hosts.items()
+        )
+        findings.append(f"resolver_divergence: {desc}")
+
+    # Gateway ARP: for each default gateway IP, collect which lladdr each host learned.
+    gateway_macs: dict[str, dict[str, list[str]]] = {}
+    for row in host_rows:
+        gws = {d["via"] for d in row["default_routes"] if d["via"]}
+        for gw in gws:
+            arp_entry = next((a for a in row["arp"] if a["ip"] == gw), None)
+            if arp_entry and arp_entry["mac"] not in {"<incomplete>", "00:00:00:00:00:00"}:
+                gateway_macs.setdefault(gw, {}).setdefault(arp_entry["mac"], []).append(row["device"])
+    for gw, by_mac in gateway_macs.items():
+        if len(by_mac) > 1:
+            desc = "; ".join(f"{mac} -> {hosts}" for mac, hosts in by_mac.items())
+            findings.append(f"arp_gateway_divergence gateway={gw}: {desc}")
+
+    return findings
+
+
+def _text_summary(payload: dict[str, Any], show_clean: bool) -> str:
+    lines = []
+    lines.append("=== INFRA SWEEP ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Scope: {', '.join(payload['scope'])}")
+    lines.append(f"Devices scanned: {payload['device_count']}")
+    lines.append(f"Flagged devices: {payload['flagged_count']}")
+    if payload["device_errors"]:
+        lines.append(f"Device errors: {len(payload['device_errors'])}")
+        for item in payload["device_errors"]:
+            lines.append(f"  - {item['device']}: {item['error']}")
+
+    # Always print what categories WERE inspected, with positive counts even
+    # at zero — so the agent can tell "we looked and found nothing" from "we
+    # didn't look." The previous compact form ("Flagged devices: 0") gave no
+    # evidence of coverage and looked identical to a no-op run.
+    nft_total = sum(c for _, c in payload["acl_fingerprints"])
+    sample_arp_lines = []
+    hosts_with_default = 0
+    hosts_with_ipv4 = 0
+    hosts_total = 0
+    static_arp_count = 0
+    fabricated_mac_count = 0
+    for entry in (payload.get("flagged_devices", []) + payload.get("clean_devices", [])):
+        if entry.get("role") != "host":
+            continue
+        hosts_total += 1
+        if any(iface["ipv4"] for iface in entry.get("interfaces", [])):
+            hosts_with_ipv4 += 1
+        if entry.get("default_routes"):
+            hosts_with_default += 1
+        for arp in entry.get("arp", []):
+            if arp.get("flag") in ("CM", "PM", "PERMANENT"):
+                static_arp_count += 1
+        for flag in entry.get("flags", []):
+            if "fabricated_mac" in flag:
+                fabricated_mac_count += 1
+        if len(sample_arp_lines) < 3 and entry.get("arp"):
+            arp_preview = ", ".join(
+                f"{a['ip']}={a['mac']}({a.get('flag','')})" for a in entry["arp"][:3]
+            )
+            sample_arp_lines.append(f"  {entry['device']}: {arp_preview}")
+    lines.append("")
+    lines.append("Categories inspected:")
+    lines.append(f"  - ACL/firewall drop fingerprints: {nft_total} device(s) with rules matched (0 means no protocol-specific drops seen)")
+    lines.append(f"  - Static ARP entries (CM/PM/PERMANENT) on hosts: {static_arp_count} found")
+    lines.append(f"  - Fabricated-pattern MACs in host ARP: {fabricated_mac_count} found")
+    lines.append(f"  - Hosts with IPv4 / with default route: {hosts_with_ipv4}/{hosts_total}, {hosts_with_default}/{hosts_total}")
+    cross = len(payload.get("cross_host_flags", []))
+    lines.append(f"  - Cross-host flags (resolver/gateway divergence): {cross}")
+    if sample_arp_lines:
+        lines.append("Sample host ARP entries (first 3):")
+        lines.extend(sample_arp_lines)
+    # Note what is NOT in this sweep so the agent doesn't assume "clean = all-clear"
+    lines.append("Note: this sweep does NOT scan for duplicate `link/ether` (use l2_snapshot for that).")
+
+    if payload["acl_fingerprints"]:
+        lines.append("ACL fingerprints found:")
+        for name, count in payload["acl_fingerprints"]:
+            lines.append(f"  - {name}: {count} device(s)")
+
+    if payload["cross_host_flags"]:
+        lines.append("Cross-host flags:")
+        for flag in payload["cross_host_flags"]:
+            lines.append(f"  - {flag}")
+
+    if payload["flagged_devices"]:
+        lines.append("")
+        lines.append("Flagged device details:")
+        for entry in payload["flagged_devices"]:
+            lines.append(f"- {entry['device']} ({entry['role']})")
+            for flag in entry["flags"]:
+                lines.append(f"    flag: {flag}")
+            if entry.get("nft_hits"):
+                for hit in entry["nft_hits"]:
+                    lines.append(f"    rule: {hit['rule']}")
+            if entry["role"] == "host":
+                default_text = ", ".join(r["raw"] for r in entry["default_routes"]) or "(none)"
+                ipv4 = [f"{iface['ifname']}: {', '.join(iface['ipv4']) or '(none)'}" for iface in entry["interfaces"]]
+                lines.append(f"    addrs: {'; '.join(ipv4)}")
+                lines.append(f"    default: {default_text}")
+                lines.append(f"    resolv: {', '.join(entry['nameservers']) or '(none)'}")
+
+    if show_clean and payload.get("clean_devices"):
+        lines.append("")
+        lines.append("Clean devices (summary):")
+        for entry in payload["clean_devices"]:
+            nft_note = f"nft={len(entry['nft_hits'])}" if entry.get("nft_hits") is not None else "nft=?"
+            lines.append(
+                f"- {entry['device']} ({entry['role']}): {nft_note}, "
+                f"routes={entry.get('route_count', '?')}, "
+                f"resolv={','.join(entry.get('nameservers', [])) or '(none)'}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Universal infrastructure sweep across every device.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=[
+            "hosts",
+            "routers",
+            "switches",
+            "servers",
+            "other_devices",
+            "bmv2_switches",
+            "ovs_switches",
+            "sdn_controllers",
+            "all",
+        ],
+        dest="groups",
+    )
+    parser.add_argument("--show-clean", action="store_true", help="Print a one-line summary for unflagged devices too.")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    api.load_machines()
+
+    groups = args.groups if args.groups else ([] if args.devices else DEFAULT_GROUPS)
+    devices = _resolve_devices(api, args.devices, groups, expand_neighbors=False)
+
+    group_index = {
+        "hosts": api.hosts,
+        "routers": api.routers,
+        "switches": api.switches,
+        "servers": dict(api.servers),
+    }
+
+    rows: list[dict[str, Any]] = []
+    for device in devices:
+        rows.append(_device_sweep(api, device, _role_of(device, group_index)))
+
+    host_rows = [row for row in rows if row.get("role") == "host" and not row.get("error")]
+    cross_host_flags = _cross_host_checks(host_rows) if host_rows else []
+    if cross_host_flags:
+        # Attach the cross-host signal to any host that shows resolver or gateway divergence,
+        # so a reviewer can trace which host triggered the flag.
+        for row in host_rows:
+            row.setdefault("flags", [])
+            for flag in cross_host_flags:
+                row["flags"].append(f"cross_host: {flag.split(':', 1)[0]}")
+
+    fingerprint_counter: Counter[str] = Counter()
+    for row in rows:
+        for hit in row.get("nft_hits") or []:
+            fingerprint_counter[hit["classification"]] += 1
+
+    flagged = [row for row in rows if row.get("flags")]
+    clean = [row for row in rows if not row.get("flags") and not row.get("error")]
+    device_errors = [{"device": row["device"], "error": row["error"]} for row in rows if row.get("error")]
+
+    payload = {
+        "lab_name": api.lab.name,
+        "scope": args.devices if args.devices else groups,
+        "device_count": len(devices),
+        "flagged_count": len(flagged),
+        "clean_count": len(clean),
+        "device_errors": device_errors,
+        "acl_fingerprints": sorted(fingerprint_counter.items()),
+        "cross_host_flags": cross_host_flags,
+        "flagged_devices": flagged,
+        # Text summary needs all records to compute per-category counts and
+        # ARP samples; JSON output filters them out for size reasons below.
+        "clean_devices": clean,
+        "clean_devices_omitted": False,
+    }
+    if args.as_json:
+        # Drop clean_devices from JSON unless --show-clean (prevents l-size
+        # JSON from ballooning past the oversized-output threshold).
+        json_payload = dict(payload)
+        if not args.show_clean:
+            json_payload["clean_devices"] = []
+            json_payload["clean_devices_omitted"] = bool(clean)
+        print(json.dumps(json_payload, indent=2, default=str))
+    else:
+        print(_text_summary(payload, show_clean=args.show_clean), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/l2_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/l2_snapshot.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+"""
+Compact Layer 2 coverage helper.
+
+This combines the most common "quiet network" L2 checks into one pass:
+- device discovery / neighbor context
+- interface state and MACs
+- bridge membership visibility
+- duplicate-MAC detection across the scanned set
+
+Use this when the agent would otherwise call several one-device L2 checks in a
+row just to answer "is there an L2-side anomaly here?".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from network_inventory import (
+    _find_duplicates,
+    _load_api_class,
+    _neighbors_from_link_map,
+    _parse_l2_inventory,
+    _resolve_devices,
+    _safe_link_map,
+)
+
+DEFAULT_GROUPS = [
+    "hosts",
+    "routers",
+    "switches",
+    "servers",
+    "bmv2_switches",
+    "ovs_switches",
+    "sdn_controllers",
+    "other_devices",
+]
+
+
+def _device_flags(interfaces: list[dict[str, Any]]) -> list[str]:
+    flags: list[str] = []
+    if not interfaces:
+        return ["no_non_loopback_interfaces"]
+
+    for interface in interfaces:
+        ifname = interface.get("ifname", "<unknown>")
+        operstate = (interface.get("operstate") or "").upper()
+        if operstate and operstate not in {"UP", "UNKNOWN"}:
+            flags.append(f"{ifname}: operstate={operstate}")
+    return flags
+
+
+def _bridge_members(interfaces: list[dict[str, Any]]) -> list[str]:
+    members = []
+    for interface in interfaces:
+        if interface.get("master"):
+            members.append(f"{interface['ifname']}->{interface['master']}")
+    return members
+
+
+def _snapshot_payload(
+    api: Any,
+    devices: list[str],
+    *,
+    include_loopback: bool,
+    include_bridges: bool,
+    show_records: bool,
+) -> dict[str, Any]:
+    link_map, warnings = _safe_link_map(api)
+    device_entries: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
+    device_errors: list[dict[str, str]] = []
+
+    for device in devices:
+        try:
+            interfaces = _parse_l2_inventory(api, device, include_loopback, include_bridges)
+        except Exception as exc:  # pragma: no cover - depends on live lab state
+            device_errors.append({"device": device, "error": str(exc)})
+            device_entries.append(
+                {
+                    "device": device,
+                    "neighbors": _neighbors_from_link_map(link_map, device),
+                    "interface_count": 0,
+                    "interfaces": [],
+                    "flags": [f"collection_failed: {exc}"],
+                }
+            )
+            continue
+
+        flags = _device_flags(interfaces)
+        device_entries.append(
+            {
+                "device": device,
+                "neighbors": _neighbors_from_link_map(link_map, device),
+                "interface_count": len(interfaces),
+                "interfaces": interfaces,
+                "bridge_members": _bridge_members(interfaces),
+                "flags": flags,
+            }
+        )
+        for interface in interfaces:
+            records.append({"device": device, **interface})
+
+    payload: dict[str, Any] = {
+        "lab_name": api.lab.name,
+        "devices_scanned": devices,
+        "device_count": len(devices),
+        "device_errors": device_errors,
+        "warnings": warnings,
+        "duplicate_macs": _find_duplicates(records),
+        "flagged_devices": [
+            {"device": entry["device"], "flags": entry["flags"]}
+            for entry in device_entries
+            if entry["flags"]
+        ],
+        "devices": device_entries,
+    }
+    if show_records:
+        payload["records"] = records
+    return payload
+
+
+def _text_summary(payload: dict[str, Any], show_clean: bool = False) -> str:
+    lines = []
+    lines.append("=== L2 SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    if payload["scope"]:
+        lines.append(f"Scope: {', '.join(payload['scope'])}")
+    lines.append(f"Devices scanned: {payload['device_count']}")
+    lines.append(f"Duplicate MAC groups: {len(payload['duplicate_macs'])}")
+    lines.append(f"Flagged devices: {len(payload['flagged_devices'])}")
+    bridge_count = sum(1 for entry in payload["devices"] if entry.get("bridge_members"))
+    lines.append(f"Devices with bridge members: {bridge_count}")
+    lines.append(f"Device errors: {len(payload['device_errors'])}")
+    if payload["warnings"]:
+        lines.append(f"Link-discovery warnings: {len(payload['warnings'])}")
+
+    if payload["duplicate_macs"]:
+        lines.append("")
+        lines.append("Duplicate MACs (this is the canonical mac_address_conflict signal):")
+        for item in payload["duplicate_macs"]:
+            lines.append(f"  - {item['mac']}: {', '.join(item['devices'])}")
+
+    if payload["flagged_devices"]:
+        lines.append("")
+        lines.append("Flagged devices:")
+        for item in payload["flagged_devices"]:
+            lines.append(f"  - {item['device']}: {', '.join(item['flags'])}")
+
+    # Only iterate per-device blocks when there are flags or --show-clean.
+    # On l-size topologies (180+ devices), the per-device dump is the bloat
+    # source and is redundant when nothing is flagged.
+    if show_clean:
+        lines.append("")
+        for entry in payload["devices"]:
+            neighbor_text = ", ".join(entry["neighbors"]) if entry["neighbors"] else "(none)"
+            lines.append(entry["device"])
+            lines.append(f"  Neighbors: {neighbor_text}")
+            lines.append(f"  Interfaces: {entry['interface_count']}")
+            if entry.get("bridge_members"):
+                lines.append(f"  Bridge members: {', '.join(entry['bridge_members'])}")
+            lines.append(f"  Flags: {', '.join(entry['flags']) if entry['flags'] else 'none'}")
+    elif not payload["duplicate_macs"] and not payload["flagged_devices"]:
+        lines.append("")
+        lines.append(f"All {payload['device_count']} devices' L2 identity is clean (no duplicate MACs, no down/missing interfaces).")
+        lines.append("Use --show-clean to dump per-device interface lists.")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact Layer 2 coverage helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=[
+            "hosts",
+            "routers",
+            "switches",
+            "servers",
+            "other_devices",
+            "bmv2_switches",
+            "ovs_switches",
+            "sdn_controllers",
+            "all",
+        ],
+        dest="groups",
+    )
+    parser.add_argument("--include-loopback", action="store_true")
+    parser.add_argument("--include-bridges", action="store_true")
+    parser.add_argument("--show-records", action="store_true")
+    parser.add_argument("--show-clean", action="store_true",
+        help="Include per-device interface dump in text mode and full devices array in JSON. Off by default to keep l-size output compact.")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--exact-devices",
+        action="store_true",
+        help="Do not auto-expand explicit device selections to directly connected neighbors.",
+    )
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    groups = args.groups if args.groups else ([] if args.devices else DEFAULT_GROUPS)
+    devices = _resolve_devices(
+        api,
+        args.devices,
+        groups,
+        expand_neighbors=(bool(args.devices) and not args.exact_devices),
+    )
+    payload = _snapshot_payload(
+        api,
+        devices,
+        include_loopback=args.include_loopback,
+        include_bridges=args.include_bridges,
+        show_records=args.show_records,
+    )
+    payload["scope"] = args.devices if args.devices else groups
+    if args.as_json:
+        # Strip the per-device interface dump from JSON unless --show-clean.
+        # On l-size topologies (180+ devices x 2-3 interfaces), the full
+        # `devices` array is the bloat source and would trigger the oversized-
+        # output detour. Keep flagged_devices, duplicate_macs, and counts.
+        if args.show_clean:
+            print(json.dumps(payload, indent=2))
+        else:
+            json_payload = dict(payload)
+            json_payload["devices"] = []
+            json_payload["devices_omitted"] = bool(payload.get("devices"))
+            print(json.dumps(json_payload, indent=2))
+    else:
+        print(_text_summary(payload, show_clean=args.show_clean), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/network_inventory.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/network_inventory.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+"""
+Skill-side discovery helper for hidden topology and L2 inventory checks.
+
+This keeps discovery logic out of the Kathara MCP server surface while still
+letting the agent enumerate devices, links, and per-device L2 state when the
+task description is only a partial sample of the lab.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SRC_ROOT = Path(__file__).resolve().parents[7]
+REPO_ROOT = SRC_ROOT.parent
+DEFAULT_MAC_GROUPS = ("hosts", "routers", "switches", "servers", "other_devices")
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def _load_api_class():
+    try:
+        from nika.service.kathara import KatharaAPIALL as KatharaAPI  # noqa: E402
+    except ModuleNotFoundError as exc:
+        venv_python = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+        raise SystemExit(
+            f"Missing project dependency '{exc.name}'. "
+            f"Run this script with the project interpreter, e.g. '{venv_python}'."
+        ) from exc
+    return KatharaAPI
+
+
+def _safe_container_name(container: Any) -> str | None:
+    labels = getattr(container, "labels", None) or {}
+    return labels.get("name") or getattr(container, "name", None)
+
+
+def _safe_link_map(api: Any) -> tuple[dict[str, list[str]], list[dict[str, Any]]]:
+    try:
+        links: dict[str, Any] = next(api.instance.get_links_stats())
+    except Exception as exc:  # pragma: no cover - depends on live lab state
+        return {}, [{"type": "get_links_failed", "message": str(exc)}]
+
+    result: dict[str, list[str]] = {}
+    warnings: list[dict[str, Any]] = []
+    for raw_name, link in links.items():
+        link_name = getattr(link, "name", None) or raw_name or "<unnamed-link>"
+        containers = getattr(link, "containers", None) or []
+        names = [name for container in containers if (name := _safe_container_name(container))]
+
+        if len(names) >= 2:
+            result[link_name] = sorted(set(names))
+            continue
+
+        warnings.append(
+            {
+                "type": "incomplete_link",
+                "link": link_name,
+                "container_count": len(containers),
+                "resolved_devices": names,
+            }
+        )
+
+    return result, warnings
+
+
+def _neighbors_from_link_map(link_map: dict[str, list[str]], host_name: str) -> list[str]:
+    neighbors: set[str] = set()
+    for devices in link_map.values():
+        if host_name not in devices:
+            continue
+        for device in devices:
+            if device != host_name:
+                neighbors.add(device)
+    return sorted(neighbors)
+
+
+def _parse_l2_inventory(api: Any, host_name: str, include_loopback: bool, include_bridges: bool) -> list[dict]:
+    result = api.exec_cmd(host_name, "ip -j addr")
+    output = "\n".join(result) if isinstance(result, list) else result
+    if not output:
+        return []
+
+    links = json.loads(output)
+    inventory = []
+    for link in links:
+        name = link.get("ifname")
+        if not name:
+            continue
+        if not include_loopback and name == "lo":
+            continue
+        if not include_bridges and "br" in name:
+            continue
+
+        ipv4 = []
+        for addr in link.get("addr_info", []):
+            if addr.get("family") != "inet":
+                continue
+            ip = addr.get("local")
+            prefix = addr.get("prefixlen")
+            if ip and not ip.startswith("127."):
+                ipv4.append(f"{ip}/{prefix}" if prefix is not None else ip)
+
+        inventory.append(
+            {
+                "ifname": name,
+                "mac": link.get("address"),
+                "operstate": link.get("operstate"),
+                "flags": link.get("flags", []),
+                "master": link.get("master"),
+                "ipv4": ipv4,
+            }
+        )
+
+    return inventory
+
+
+def _flatten_server_groups(server_groups: dict) -> list[str]:
+    devices = []
+    for members in server_groups.values():
+        devices.extend(members)
+    return sorted(set(devices))
+
+
+def _lab_groups(api: Any) -> dict[str, list[str] | dict]:
+    api.load_machines()
+    groups = {
+        "hosts": api.hosts,
+        "routers": api.routers,
+        "switches": api.switches,
+        "servers": dict(api.servers),
+        "bmv2_switches": api.bmv2_switches,
+        "ovs_switches": api.ovs_switches,
+        "sdn_controllers": api.sdn_controllers,
+    }
+    known_devices = set(groups["hosts"])
+    known_devices.update(groups["routers"])
+    known_devices.update(groups["switches"])
+    known_devices.update(_flatten_server_groups(groups["servers"]))
+    known_devices.update(groups["bmv2_switches"])
+    known_devices.update(groups["ovs_switches"])
+    known_devices.update(groups["sdn_controllers"])
+    groups["other_devices"] = sorted(set(api.lab.machines.keys()) - known_devices)
+    return groups
+
+
+def _inventory_summary(api: Any) -> dict:
+    groups = _lab_groups(api)
+    link_map, warnings = _safe_link_map(api)
+    return {
+        "lab_name": api.lab.name,
+        **groups,
+        "links": link_map,
+        "warnings": warnings,
+    }
+
+
+def _preview(items: list[str], limit: int = 12) -> str:
+    if not items:
+        return "(none)"
+    preview = ", ".join(items[:limit])
+    if len(items) > limit:
+        preview += f" ... (+{len(items) - limit} more)"
+    return preview
+
+
+def _summary_text(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== NETWORK INVENTORY ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Hosts: {len(payload['hosts'])} [{_preview(payload['hosts'])}]")
+    lines.append(f"Routers: {len(payload['routers'])} [{_preview(payload['routers'])}]")
+    lines.append(f"Switches: {len(payload['switches'])} [{_preview(payload['switches'])}]")
+
+    server_total = sum(len(members) for members in payload["servers"].values())
+    if payload["servers"]:
+        lines.append(f"Servers: {server_total}")
+        for role, members in sorted(payload["servers"].items()):
+            lines.append(f"  {role}: {len(members)} [{_preview(sorted(members))}]")
+    else:
+        lines.append("Servers: 0")
+
+    if payload["bmv2_switches"]:
+        lines.append(f"BMv2 switches: {len(payload['bmv2_switches'])} [{_preview(payload['bmv2_switches'])}]")
+    if payload["ovs_switches"]:
+        lines.append(f"OVS switches: {len(payload['ovs_switches'])} [{_preview(payload['ovs_switches'])}]")
+    if payload["sdn_controllers"]:
+        lines.append(
+            f"SDN controllers: {len(payload['sdn_controllers'])} [{_preview(payload['sdn_controllers'])}]"
+        )
+    if payload["other_devices"]:
+        lines.append(f"Other devices: {len(payload['other_devices'])} [{_preview(payload['other_devices'])}]")
+
+    lines.append(f"Links discovered: {len(payload['links'])}")
+    for link_name, devices in sorted(payload["links"].items()):
+        lines.append(f"  {link_name}: {', '.join(devices)}")
+
+    if payload["warnings"]:
+        lines.append("Warnings:")
+        for warning in payload["warnings"]:
+            lines.append(f"  {warning}")
+    return "\n".join(lines) + "\n"
+
+
+def _connected_text(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== DIRECT NEIGHBORS ===")
+    lines.append(f"Device: {payload['device']}")
+    lines.append(f"Neighbors: {_preview(payload['neighbors'], limit=len(payload['neighbors']) or 1)}")
+    if payload["warnings"]:
+        lines.append("Warnings:")
+        for warning in payload["warnings"]:
+            lines.append(f"  {warning}")
+    return "\n".join(lines) + "\n"
+
+
+def _l2_text(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== L2 INVENTORY ===")
+    lines.append(f"Device: {payload['device']}")
+    if payload.get("error"):
+        lines.append(f"Error: {payload['error']}")
+        return "\n".join(lines) + "\n"
+
+    if not payload["interfaces"]:
+        lines.append("Interfaces: none")
+        return "\n".join(lines) + "\n"
+
+    for interface in payload["interfaces"]:
+        ipv4_text = ", ".join(interface["ipv4"]) if interface["ipv4"] else "(none)"
+        flags_text = ", ".join(interface["flags"]) if interface["flags"] else "(none)"
+        lines.append(interface["ifname"])
+        lines.append(f"  MAC: {interface['mac'] or '(none)'}")
+        lines.append(f"  Operstate: {interface['operstate'] or '(unknown)'}")
+        lines.append(f"  IPv4: {ipv4_text}")
+        lines.append(f"  Flags: {flags_text}")
+        if interface.get("master"):
+            lines.append(f"  Master: {interface['master']}")
+    return "\n".join(lines) + "\n"
+
+
+def _macs_text(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== MAC INVENTORY ===")
+    if payload["groups_requested"]:
+        lines.append(f"Scope: {', '.join(payload['groups_requested'])}")
+    lines.append(f"Devices scanned: {payload['device_count']}")
+    lines.append(f"Devices: {_preview(payload['devices_scanned'], limit=len(payload['devices_scanned']) or 1)}")
+    lines.append(f"Interfaces scanned: {payload['interface_count']}")
+    lines.append(f"Duplicate MAC groups: {payload['duplicate_count']}")
+    if payload["neighbor_expansion"]:
+        lines.append("Neighbor expansion: enabled")
+    if payload["device_errors"]:
+        lines.append("Device errors:")
+        for item in payload["device_errors"]:
+            lines.append(f"  {item['device']}: {item['error']}")
+
+    if payload["duplicates"]:
+        lines.append("Duplicate MACs:")
+        for item in payload["duplicates"]:
+            lines.append(f"  {item['mac']}: {', '.join(item['devices'])}")
+    else:
+        lines.append("Duplicate MACs: none")
+    return "\n".join(lines) + "\n"
+
+
+def _resolve_devices(
+    api: Any,
+    devices: list[str],
+    groups: list[str],
+    *,
+    expand_neighbors: bool,
+) -> list[str]:
+    inventory = _lab_groups(api)
+    resolved = list(devices)
+    for group in groups:
+        if group == "all":
+            resolved.extend(inventory["hosts"])
+            resolved.extend(inventory["routers"])
+            resolved.extend(inventory["switches"])
+            resolved.extend(_flatten_server_groups(inventory["servers"]))
+            resolved.extend(inventory["bmv2_switches"])
+            resolved.extend(inventory["ovs_switches"])
+            resolved.extend(inventory["sdn_controllers"])
+            resolved.extend(inventory["other_devices"])
+            continue
+        if group == "servers":
+            resolved.extend(_flatten_server_groups(inventory["servers"]))
+            continue
+        if group == "other_devices":
+            resolved.extend(inventory["other_devices"])
+            continue
+        resolved.extend(inventory[group])
+
+    if expand_neighbors and resolved:
+        link_map, _ = _safe_link_map(api)
+        pending = list(resolved)
+        seen = set(resolved)
+        while pending:
+            device = pending.pop()
+            for neighbor in _neighbors_from_link_map(link_map, device):
+                if neighbor in seen:
+                    continue
+                seen.add(neighbor)
+                pending.append(neighbor)
+        resolved = list(seen)
+
+    return sorted(set(resolved))
+
+
+def _find_duplicates(records: Iterable[dict], *, include_records: bool = False) -> list[dict]:
+    by_mac: dict[str, list[dict]] = defaultdict(list)
+    for record in records:
+        mac = record.get("mac")
+        if mac:
+            by_mac[mac].append(record)
+
+    duplicates = []
+    for mac, entries in sorted(by_mac.items()):
+        devices = sorted({entry["device"] for entry in entries})
+        if len(devices) < 2:
+            continue
+        duplicates.append(
+            {
+                "mac": mac,
+                "devices": devices,
+                "record_count": len(entries),
+                **({"records": entries} if include_records else {}),
+            }
+        )
+    return duplicates
+
+
+def main() -> int:
+    # CLI surface is topology-only. Per-device L2 identity and duplicate-MAC
+    # detection are owned by `l2_snapshot.py`; this script exposes only the
+    # topology / grouping / neighbor view. The L2 and MAC helper functions
+    # remain importable for other scripts.
+    parser = argparse.ArgumentParser(description="Discover lab topology and device groupings.")
+    parser.set_defaults(command="summary", as_json=False)
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    subparsers = parser.add_subparsers(dest="command")
+
+    summary_parser = subparsers.add_parser("summary", help="Show grouped devices plus discovered links.")
+    summary_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    connected_parser = subparsers.add_parser("connected", help="Show directly connected devices for a node.")
+    connected_parser.add_argument("device")
+    connected_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    args = parser.parse_args()
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+
+    if args.command == "summary":
+        payload = _inventory_summary(api)
+        if args.as_json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(_summary_text(payload), end="")
+        return 0
+
+    if args.command == "connected":
+        link_map, warnings = _safe_link_map(api)
+        payload = {
+            "device": args.device,
+            "neighbors": _neighbors_from_link_map(link_map, args.device),
+            "warnings": warnings,
+        }
+        if args.as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(_connected_text(payload), end="")
+        return 0
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/ospf_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/ospf_snapshot.py
@@ -1,0 +1,810 @@
+#!/usr/bin/env python
+"""
+One-pass OSPF coverage helper for diagnosis methodology and the OSPF fault skill.
+
+This gathers high-signal OSPF data across all discovered routers without
+changing the Kathara MCP server surface:
+- FRR process status
+- OSPF network statements / areas
+- OSPF neighbor state summary
+- OSPF route count
+
+The helper intentionally uses single-quoted `vtysh -c '...'` commands because
+the underlying `exec_cmd()` wrapper escapes double quotes in a way that can
+silently corrupt FRR commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SRC_ROOT = Path(__file__).resolve().parents[7]
+REPO_ROOT = SRC_ROOT.parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+NETWORK_RE = re.compile(r"^\s*network\s+(\S+)\s+area\s+(\S+)\s*$")
+
+
+def _load_api_class():
+    try:
+        from nika.service.kathara import KatharaAPIALL as KatharaAPI  # noqa: E402
+    except ModuleNotFoundError as exc:
+        venv_python = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+        raise SystemExit(
+            f"Missing project dependency '{exc.name}'. "
+            f"Run this script with the project interpreter, e.g. '{venv_python}'."
+        ) from exc
+    return KatharaAPI
+
+
+def _load_routers(api: Any) -> list[str]:
+    api.load_machines()
+    return list(api.routers)
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _run(api: Any, router: str, command: str) -> tuple[str, str | None]:
+    raw = api.exec_cmd(router, command)
+    if _command_failed(raw):
+        return raw, raw
+    return raw, None
+
+
+FRR_DAEMONS = ("zebra", "ospfd", "watchfrr")
+
+
+def _parse_ps_daemons(raw: str) -> dict[str, bool]:
+    """Parse `ps aux` output and detect FRR daemons by actual command, not by line-wide substring.
+
+    The previous `"zebra" in raw` check was fragile: the `ps aux | grep -E '...'` wrapper
+    itself appears in the output, and the literal pattern 'zebra|ospfd|watchfrr' inside a
+    bash -c line can match all three even when no daemon is running. We instead inspect the
+    final command column of each ps row and reject lines whose command is grep/bash/sh
+    running our own probe.
+    """
+    found = {name: False for name in FRR_DAEMONS}
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(None, 10)
+        if len(parts) < 11:
+            continue
+        command = parts[10]
+        # Drop the ps/grep/bash wrapper lines that run the probe itself.
+        command_head = command.split()[0].rsplit("/", 1)[-1] if command else ""
+        if command_head in {"grep", "bash", "sh", "ps"}:
+            continue
+        # Extract the executable name from the command (argv[0]); compare against daemons.
+        binary = command.split()[0].rsplit("/", 1)[-1] if command else ""
+        for daemon in FRR_DAEMONS:
+            if binary == daemon or binary.startswith(f"{daemon}-") or binary.startswith(f"{daemon}.") or binary == daemon + "d":
+                found[daemon] = True
+    return found
+
+
+def _frr_sockets(api: Any, router: str) -> dict[str, Any]:
+    """Check the FRR control sockets and the frr systemd service as independent signals."""
+    raw, error = _run(
+        api,
+        router,
+        "ls -1 /var/run/frr/*.vty /var/run/frr/*.pid 2>/dev/null; "
+        "echo '---'; "
+        "systemctl is-active frr 2>/dev/null || true; "
+        "echo '---'; "
+        "vtysh -c 'show version' 2>&1 | head -3 || true",
+    )
+    sections = raw.split("---")
+    listing = sections[0] if len(sections) > 0 else ""
+    systemd_state = sections[1].strip() if len(sections) > 1 else ""
+    vtysh_probe = sections[2].strip() if len(sections) > 2 else ""
+
+    sockets = {
+        "zebra_vty": "zebra.vty" in listing,
+        "ospfd_vty": "ospfd.vty" in listing,
+        "watchfrr_pid": "watchfrr.pid" in listing,
+    }
+    systemd_active = systemd_state.splitlines()[0].strip().lower() if systemd_state else ""
+    vtysh_ok = "FRRouting" in vtysh_probe or "Welcome" in vtysh_probe
+    vtysh_dead = "failed to connect" in vtysh_probe.lower() or "no such file" in vtysh_probe.lower()
+    return {
+        "error": error,
+        "sockets": sockets,
+        "systemd_state": systemd_active,
+        "vtysh_probe": vtysh_probe,
+        "vtysh_ok": vtysh_ok,
+        "vtysh_dead": vtysh_dead,
+    }
+
+
+def _process_status(api: Any, router: str) -> dict[str, Any]:
+    ps_raw, ps_error = _run(api, router, "ps -eo pid,user,pcpu,pmem,cmd --sort=-pcpu")
+    daemons = _parse_ps_daemons(ps_raw) if not ps_error else {name: False for name in FRR_DAEMONS}
+    socket_info = _frr_sockets(api, router)
+
+    # Health model: on Kathara, `ps -eo` does NOT always show `watchfrr` and
+    # `zebra` even when they are running normally (they can be invoked in a way
+    # that hides them from the standard process listing). Conversely, the vtysh
+    # control socket and the zebra/ospfd unix sockets ARE reliable signals: if
+    # vtysh answers `show version` and the sockets exist, FRR is up; if vtysh
+    # fails to connect and the sockets are missing, FRR is down.
+    #
+    # We therefore treat socket/vtysh as authoritative and demote ps to a
+    # tie-breaker. `systemd_state == active` is not reliable on Kathara either
+    # (systemd is usually inactive inside the containers), so we ignore it
+    # unless it actively contradicts the other signals.
+    signal_vtysh = socket_info["vtysh_ok"] and not socket_info["vtysh_dead"]
+    signal_sockets = socket_info["sockets"]["zebra_vty"] and socket_info["sockets"]["ospfd_vty"]
+    signal_ps = all(daemons.values())
+
+    # Authoritative: sockets + vtysh. If both indicate alive, the router is
+    # healthy regardless of what ps shows. Only when BOTH sockets AND vtysh
+    # fail do we call the router unhealthy.
+    healthy = (not socket_info["error"]) and signal_vtysh and signal_sockets
+    return {
+        "router": router,
+        "raw": ps_raw,
+        "error": ps_error,
+        "zebra": daemons["zebra"],
+        "ospfd": daemons["ospfd"],
+        "watchfrr": daemons["watchfrr"],
+        "systemd_state": socket_info["systemd_state"],
+        "sockets": socket_info["sockets"],
+        "vtysh_ok": socket_info["vtysh_ok"],
+        "vtysh_dead": socket_info["vtysh_dead"],
+        "signals": {
+            "ps": signal_ps,
+            "sockets": signal_sockets,
+            "vtysh": signal_vtysh,
+        },
+        "healthy": healthy,
+    }
+
+
+def _extract_ospf_networks(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show running-config'")
+    records: list[dict[str, str]] = []
+    in_ospf = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped == "router ospf":
+            in_ospf = True
+            continue
+        if in_ospf and stripped in {"exit", "!"}:
+            if stripped == "!":
+                break
+            continue
+        if not in_ospf:
+            continue
+        match = NETWORK_RE.match(line)
+        if match:
+            records.append({"network": match.group(1), "area": _normalize_area(match.group(2))})
+
+    return {
+        "raw": raw,
+        "error": error,
+        "records": records,
+    }
+
+
+def _parse_neighbors(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show ip ospf neighbor'")
+    neighbors = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("Neighbor ID"):
+            continue
+        parts = stripped.split()
+        if len(parts) < 7:
+            continue
+        neighbors.append(
+            {
+                "neighbor_id": parts[0],
+                "state": parts[2],
+                "address": parts[5],
+                "interface": parts[6],
+            }
+        )
+
+    states = Counter(entry["state"] for entry in neighbors)
+    return {
+        "raw": raw,
+        "error": error,
+        "count": len(neighbors),
+        "all_full": bool(neighbors) and all(state.startswith("Full") for state in states),
+        "states": dict(states),
+        "neighbors": neighbors,
+    }
+
+
+AREA_HEADER_RE = re.compile(r"^\s*Area ID:\s*(\S+)")
+AREA_IFACE_RE = re.compile(
+    r"Number of interfaces in this area:\s*Total:\s*(\d+),\s*Active:\s*(\d+)"
+)
+AREA_ADJ_RE = re.compile(r"Number of fully adjacent neighbors in this area:\s*(\d+)")
+
+
+def _normalize_area(area: str) -> str:
+    """Canonicalize OSPF area ID to dotted-decimal form (A.B.C.D).
+
+    FRR emits areas in two surface forms:
+      - `show running-config` network statements: plain decimal ('area 1', 'area 66')
+      - `show ip ospf` / `show ip ospf interface`: dotted-decimal ('Area ID: 0.0.0.1')
+
+    Every area is a 32-bit identifier internally. We canonicalize to dotted
+    form so the snapshot matches what FRR prints in `show ip ospf` and so
+    small areas are unambiguous (1 vs 0.0.0.1 both collapse to 0.0.0.1
+    instead of the ambiguous short form).
+    """
+    if not area:
+        return area
+    stripped = area.strip()
+    parts = stripped.split(".")
+    if len(parts) == 4:
+        try:
+            octets = [int(p) for p in parts]
+        except ValueError:
+            return stripped
+        if all(0 <= o <= 255 for o in octets):
+            return f"{octets[0]}.{octets[1]}.{octets[2]}.{octets[3]}"
+        return stripped
+    try:
+        n = int(stripped)
+    except ValueError:
+        return stripped
+    if 0 <= n <= 0xFFFFFFFF:
+        return f"{(n >> 24) & 0xFF}.{(n >> 16) & 0xFF}.{(n >> 8) & 0xFF}.{n & 0xFF}"
+    return stripped
+
+
+def _parse_show_ip_ospf(raw: str) -> list[dict[str, Any]]:
+    """Parse `vtysh -c 'show ip ospf'` into per-area active-participation records.
+
+    Each record has:
+      - `area`: normalized area ID (e.g. "0", "1", "66")
+      - `interfaces_total`, `interfaces_active`
+      - `full_adjacencies`: number of fully adjacent neighbors in this area
+
+    This is the authoritative view of what areas a router is ACTIVELY running,
+    independent of `network X area Y` statement parsing. It is the signal that
+    reveals ospf_area_misconfiguration: if a router has an area with `>=1`
+    active interface but `0` full adjacencies, that area is broken (typically
+    because its peer is in a different area).
+    """
+    areas: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+
+    for line in raw.splitlines():
+        header = AREA_HEADER_RE.match(line)
+        if header:
+            if current is not None:
+                areas.append(current)
+            current = {
+                "area": _normalize_area(header.group(1)),
+                "area_raw": header.group(1),
+                "interfaces_total": None,
+                "interfaces_active": None,
+                "full_adjacencies": None,
+            }
+            continue
+        if current is None:
+            continue
+        iface = AREA_IFACE_RE.search(line)
+        if iface:
+            current["interfaces_total"] = int(iface.group(1))
+            current["interfaces_active"] = int(iface.group(2))
+            continue
+        adj = AREA_ADJ_RE.search(line)
+        if adj:
+            current["full_adjacencies"] = int(adj.group(1))
+            continue
+    if current is not None:
+        areas.append(current)
+    return areas
+
+
+def _extract_active_areas(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show ip ospf'")
+    records = _parse_show_ip_ospf(raw) if not error else []
+    return {"raw": raw, "error": error, "records": records}
+
+
+# `show ip ospf interface` gives per-interface state. Each interface block:
+#   eth2 is up
+#     ...
+#     Internet Address 172.16.0.6/31, Area 0.0.0.1
+#     ...
+#     State Point-To-Point, Priority 1
+#     ...
+#     Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
+#     Neighbor Count is 1, Adjacent neighbor count is 1
+IFACE_HEADER_RE = re.compile(r"^(\S+)\s+is\s+(up|down|detached)\b", re.IGNORECASE)
+IFACE_AREA_RE = re.compile(r"Area\s+(\S+)", re.IGNORECASE)
+IFACE_ADDR_RE = re.compile(r"Internet Address\s+([\d.]+/\d+)")
+IFACE_STATE_RE = re.compile(r"State\s+([A-Za-z0-9_-]+)")
+IFACE_NEIGH_RE = re.compile(
+    r"Neighbor Count is\s+(\d+),\s*Adjacent neighbor count is\s+(\d+)"
+)
+IFACE_HELLO_RE = re.compile(r"Hello\s+(\d+)s,\s*Dead\s+(\d+)s")
+
+
+def _parse_show_ip_ospf_interface(raw: str) -> list[dict[str, Any]]:
+    """Parse per-interface OSPF state. Each record has:
+      ifname, up, area (normalized), state, neighbor_count, adjacent_count,
+      hello_interval, dead_interval.
+    """
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for line in raw.splitlines():
+        header = IFACE_HEADER_RE.match(line.strip())
+        if header:
+            if current is not None:
+                records.append(current)
+            current = {
+                "ifname": header.group(1),
+                "up": header.group(2).lower() == "up",
+                "area": None,
+                "address": None,
+                "state": None,
+                "neighbor_count": None,
+                "adjacent_count": None,
+                "hello_interval": None,
+                "dead_interval": None,
+            }
+            continue
+        if current is None:
+            continue
+        m_area = IFACE_AREA_RE.search(line)
+        if m_area and current["area"] is None:
+            current["area"] = _normalize_area(m_area.group(1).rstrip(","))
+        m_addr = IFACE_ADDR_RE.search(line)
+        if m_addr and current["address"] is None:
+            current["address"] = m_addr.group(1)
+        if m_area or m_addr:
+            continue
+        m = IFACE_STATE_RE.search(line)
+        if m and current["state"] is None:
+            current["state"] = m.group(1)
+            continue
+        m = IFACE_NEIGH_RE.search(line)
+        if m:
+            current["neighbor_count"] = int(m.group(1))
+            current["adjacent_count"] = int(m.group(2))
+            continue
+        m = IFACE_HELLO_RE.search(line)
+        if m:
+            current["hello_interval"] = int(m.group(1))
+            current["dead_interval"] = int(m.group(2))
+            continue
+    if current is not None:
+        records.append(current)
+    return records
+
+
+def _extract_active_interfaces(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show ip ospf interface'")
+    records = _parse_show_ip_ospf_interface(raw) if not error else []
+    return {"raw": raw, "error": error, "records": records}
+
+
+def _count_ospf_routes(api: Any, router: str) -> dict[str, Any]:
+    raw, error = _run(api, router, "vtysh -c 'show ip route ospf'")
+    route_lines = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("Codes:", ">", "C>", "K>", "S>", "C ", "K ", "S ")):
+            continue
+        if stripped.startswith("O"):
+            route_lines.append(stripped)
+    return {
+        "raw": raw,
+        "error": error,
+        "count": len(route_lines),
+    }
+
+
+def _router_snapshot(api: Any, router: str) -> dict[str, Any]:
+    process = _process_status(api, router)
+    networks = _extract_ospf_networks(api, router)
+    neighbors = _parse_neighbors(api, router)
+    ospf_routes = _count_ospf_routes(api, router)
+    active_areas = _extract_active_areas(api, router)
+    active_interfaces = _extract_active_interfaces(api, router)
+    return {
+        "router": router,
+        "process": process,
+        "ospf_networks": networks["records"],
+        "areas": sorted({item["area"] for item in networks["records"]}),
+        "active_areas": active_areas["records"],
+        "active_interfaces": active_interfaces["records"],
+        "neighbors": neighbors,
+        "ospf_routes": ospf_routes,
+        "errors": {
+            "process": process["error"],
+            "active_areas": active_areas["error"],
+            "active_interfaces": active_interfaces["error"],
+            "config": networks["error"],
+            "neighbors": neighbors["error"],
+            "routes": ospf_routes["error"],
+        },
+    }
+
+
+def _flags(snapshot: dict[str, Any]) -> list[str]:
+    router = snapshot["router"]
+    flags: list[str] = []
+    process = snapshot["process"]
+    neighbors = snapshot["neighbors"]
+    ospf_networks = snapshot["ospf_networks"]
+    errors = snapshot["errors"]
+
+    for phase, error in errors.items():
+        if error:
+            flags.append(f"{router}: {phase} command failed")
+
+    if not process["healthy"]:
+        signals = process.get("signals", {})
+        sockets = process.get("sockets") or {}
+        # Only emit strong "FRR down" signals. In Kathara, `ps` often fails to
+        # show watchfrr/zebra even when they're healthy, so do not flag on
+        # ps-only absence. The authoritative signals are vtysh and the control
+        # sockets — flag when either fails.
+        if not signals.get("vtysh", True):
+            flags.append(f"{router}: vtysh probe failed (FRR control plane unreachable)")
+        missing_sockets = [
+            name for name in ("zebra_vty", "ospfd_vty")
+            if not sockets.get(name, False)
+        ]
+        if missing_sockets:
+            flags.append(
+                f"{router}: FRR control sockets missing ({', '.join(missing_sockets)}) — daemon likely down"
+            )
+    if not ospf_networks and not errors["config"]:
+        flags.append(f"{router}: no OSPF network statements")
+    if neighbors["count"] == 0 and not errors["neighbors"]:
+        flags.append(f"{router}: zero OSPF neighbors")
+    elif not neighbors["all_full"] and not errors["neighbors"]:
+        flags.append(f"{router}: non-Full neighbors present: {neighbors['states']}")
+
+    # Per-area adjacency failure: if an area has >=1 active interface but 0
+    # full adjacencies, the adjacency process has broken on every link in that
+    # area. The classic cause is one side of the link advertising a different
+    # area ID — so this is the symptom-level signal the agent should key on.
+    for entry in snapshot.get("active_areas", []) or []:
+        adjacencies = entry.get("full_adjacencies")
+        active = entry.get("interfaces_active")
+        if adjacencies == 0 and active and active > 0:
+            flags.append(
+                f"{router}: area {entry['area']} has 0 full adjacencies across "
+                f"{active} active interface(s) — peer mismatch suspected"
+            )
+
+    # Per-INTERFACE checks (catches partial failures the per-area aggregate
+    # hides — e.g. one uplink broken while a sibling host-facing interface is
+    # normally adj=0).
+    network_records = snapshot.get("ospf_networks") or []
+    network_areas_by_prefix = {(r.get("network") or "").strip(): r.get("area") for r in network_records}
+    for iface in snapshot.get("active_interfaces", []) or []:
+        ifname = iface.get("ifname", "?")
+        # Interface declared down at the OSPF layer.
+        if iface.get("up") is False:
+            flags.append(f"{router}: OSPF interface {ifname} is down")
+        # Interface has neighbors but none reached Full state.
+        nbr = iface.get("neighbor_count")
+        adj = iface.get("adjacent_count")
+        if nbr is not None and adj is not None and nbr > 0 and adj < nbr:
+            flags.append(
+                f"{router}: OSPF interface {ifname} has {nbr} neighbor(s) but only {adj} adjacent "
+                f"(state={iface.get('state')}, area={iface.get('area')}) — peer not reaching Full"
+            )
+        # Interface running in /31 router-link subnet but no neighbor at all
+        # (broken uplink, classic ospf_neighbor_missing fingerprint).
+        addr = iface.get("address") or ""
+        if addr.endswith("/31") and nbr == 0:
+            flags.append(
+                f"{router}: OSPF interface {ifname} on point-to-point link {addr} has 0 neighbors "
+                f"(area={iface.get('area')}) — adjacency never formed"
+            )
+        # Interface-level area override that contradicts the router's network
+        # statement covering the same prefix (sneaky `ip ospf area X` injection).
+        # Match by IP containment (not string prefix) so /31 links inside the
+        # same /24 are not cross-matched against each other's network stanzas.
+        if addr and iface.get("area") is not None:
+            try:
+                iface_ip = ipaddress.ip_interface(addr).ip
+            except ValueError:
+                iface_ip = None
+            if iface_ip is not None:
+                best: tuple[int, str, Any] | None = None
+                for prefix, stmt_area in network_areas_by_prefix.items():
+                    if not prefix or "/" not in prefix:
+                        continue
+                    try:
+                        net = ipaddress.ip_network(prefix, strict=False)
+                    except ValueError:
+                        continue
+                    if iface_ip in net:
+                        # Longest-prefix wins — the most specific network
+                        # statement is the one that covers this interface.
+                        if best is None or net.prefixlen > best[0]:
+                            best = (net.prefixlen, prefix, stmt_area)
+                if best is not None:
+                    _, _, stmt_area = best
+                    if stmt_area is not None and stmt_area != iface.get("area"):
+                        flags.append(
+                            f"{router}: OSPF interface {ifname} ({addr}) is running in area "
+                            f"{iface.get('area')} but the matching network statement declares area "
+                            f"{stmt_area} — interface-level area override"
+                        )
+    return flags
+
+
+def _area_consistency_flags(snapshots: list[dict[str, Any]]) -> list[str]:
+    """Cross-router OSPF area consistency check.
+
+    Per-router snapshots already flag "zero neighbors" and "non-Full" when an
+    adjacency cannot form. But ospf_area_misconfiguration is the sneaky case
+    where a router still has most of its neighbors Full — only the one
+    interface whose area was changed to a wrong value is silent. In that case
+    the per-router view is locally clean and the fault is only visible when
+    you cross-reference multiple routers' `network X/Y area Z` statements.
+
+    For every network prefix appearing in any router's OSPF config, group by
+    the declared area. If the same prefix is declared under >1 area across
+    the fleet, that is a direct area mismatch and is surfaced as a flag.
+
+    Also surfaces area-set asymmetry: a router whose advertised area set is a
+    strict subset / superset of its directly-adjacent Full neighbors' areas.
+    (This is a weaker signal and is labeled `area_set_divergence`.)
+    """
+    by_network: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    router_areas: dict[str, set[str]] = {}
+    for snapshot in snapshots:
+        router = snapshot["router"]
+        router_areas[router] = set(snapshot.get("areas") or [])
+        for record in snapshot.get("ospf_networks") or []:
+            network = record.get("network")
+            area = record.get("area")
+            if not network or area is None:
+                continue
+            by_network[network][area].append(router)
+
+    flags: list[str] = []
+    for network, area_groups in sorted(by_network.items()):
+        if len(area_groups) < 2:
+            continue
+        parts: list[str] = []
+        for area, routers_for_area in sorted(area_groups.items()):
+            parts.append(f"area {area}: {', '.join(sorted(set(routers_for_area)))}")
+        flags.append(
+            f"ospf_area_mismatch: network {network} declared under multiple areas -> "
+            + " | ".join(parts)
+        )
+
+    # Area-set divergence: compare each router's area set with the union of
+    # areas reported by its Full neighbors. A router that advertises an area
+    # no neighbor agrees on, or refuses an area every neighbor has, is
+    # suspicious even when no neighbor is missing.
+    neighbor_areas_by_router: dict[str, set[str]] = defaultdict(set)
+    for snapshot in snapshots:
+        router = snapshot["router"]
+        local_areas = router_areas.get(router, set())
+        for entry in snapshot.get("neighbors", {}).get("neighbors", []):
+            state = entry.get("state") or ""
+            if not state.startswith("Full"):
+                continue
+            neighbor_id = entry.get("neighbor_id")
+            if not neighbor_id:
+                continue
+            # neighbor_id is typically a router-id IP, not a hostname; match
+            # against any router whose advertised areas intersect this router.
+            for other in router_areas:
+                if other == router:
+                    continue
+                if router_areas[other] & local_areas:
+                    neighbor_areas_by_router[router] |= router_areas[other]
+
+    for router, local in sorted(router_areas.items()):
+        if not local:
+            continue
+        peers = neighbor_areas_by_router.get(router, set())
+        if not peers:
+            continue
+        only_local = local - peers
+        if only_local:
+            flags.append(
+                f"{router}: area_set_divergence: areas {sorted(only_local)} declared locally "
+                f"but not seen on any Full peer (peer areas: {sorted(peers)})"
+            )
+
+    # Orphaned active area: an area ID that one router is actively running
+    # (per `show ip ospf`) but that no other router participates in. This is
+    # the direct fingerprint of the sed-based area-misconfig injector — the
+    # faulty router ends up in an area like "66" that no peer has. We report
+    # it separately from the network-statement cross-check above because the
+    # running-process view can diverge from the statement view if the daemon
+    # refused or silently reloaded part of the config.
+    active_area_to_routers: dict[str, list[str]] = defaultdict(list)
+    for snapshot in snapshots:
+        router = snapshot["router"]
+        for entry in snapshot.get("active_areas", []) or []:
+            active_area_to_routers[entry["area"]].append(router)
+    for area, routers_for_area in sorted(active_area_to_routers.items()):
+        if len(routers_for_area) == 1:
+            owner = routers_for_area[0]
+            flags.append(
+                f"{owner}: orphaned_active_area {area} — active on this router only, no peer shares it"
+            )
+    return flags
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== OSPF SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Routers scanned: {len(payload['routers'])}")
+    if payload["flags"]:
+        lines.append("Flags:")
+        for flag in payload["flags"]:
+            lines.append(f"  - {flag}")
+    else:
+        lines.append("Flags: none")
+
+    # Coverage summary so the agent can see what was actually inspected, and
+    # which per-router data points are worth scanning even when no flag fired.
+    routers = payload.get("routers", [])
+    healthy_vtysh = sum(1 for r in routers if (r.get("process") or {}).get("vtysh_ok"))
+    sockets_ok = sum(
+        1 for r in routers
+        if (r.get("process") or {}).get("sockets", {}).get("zebra_vty")
+        and (r.get("process") or {}).get("sockets", {}).get("ospfd_vty")
+    )
+    zero_neighbors = sum(1 for r in routers if (r.get("neighbors") or {}).get("count", 0) == 0)
+    non_full = sum(1 for r in routers if not (r.get("neighbors") or {}).get("all_full") and (r.get("neighbors") or {}).get("count", 0) > 0)
+    partial_adj = []
+    for r in routers:
+        for area in r.get("active_areas", []) or []:
+            adj = area.get("full_adjacencies")
+            iface_a = area.get("interfaces_active")
+            if adj is not None and iface_a is not None and adj < iface_a:
+                partial_adj.append(f"{r['router']}/area-{area['area']}(adj={adj}<iface={iface_a})")
+    # Per-interface signals: count broken/suspicious interfaces across all
+    # routers. These distinguish "broken uplink" from "host-facing no-peer".
+    iface_total = 0
+    iface_down = 0
+    iface_p2p_no_neighbor = 0
+    iface_partial_adj = 0
+    for r in routers:
+        for iface in r.get("active_interfaces", []) or []:
+            iface_total += 1
+            if iface.get("up") is False:
+                iface_down += 1
+            addr = iface.get("address") or ""
+            nbr = iface.get("neighbor_count")
+            adj = iface.get("adjacent_count")
+            if addr.endswith("/31") and nbr == 0:
+                iface_p2p_no_neighbor += 1
+            if nbr is not None and adj is not None and nbr > 0 and adj < nbr:
+                iface_partial_adj += 1
+    lines.append("")
+    lines.append("Coverage inspected:")
+    lines.append(f"  - FRR daemon health (vtysh + control sockets): {healthy_vtysh}/{len(routers)} vtysh ok, {sockets_ok}/{len(routers)} both sockets present")
+    lines.append(f"  - OSPF neighbors: {zero_neighbors} routers with zero, {non_full} with non-Full")
+    lines.append(f"  - Per-area adj < iface (some interface in the area has 0 adjacencies — normal for host-facing access ports, suspicious on uplinks): {len(partial_adj)}")
+    lines.append(f"  - Per-interface state: {iface_total} OSPF interfaces total | down: {iface_down} | point-to-point with 0 neighbors: {iface_p2p_no_neighbor} | with partial adjacency: {iface_partial_adj}")
+    if partial_adj:
+        for line in partial_adj[:10]:
+            lines.append(f"    {line}")
+    lines.append("Note: in Kathara, watchfrr=no / zebra=no in the per-router data is baseline noise (kernel-threaded). Authoritative health = vtysh + sockets.")
+    lines.append("")
+    for item in payload["routers"]:
+        proc = item["process"]
+        neigh = item["neighbors"]
+        errors = item["errors"]
+        areas = ", ".join(item["areas"]) if item["areas"] else "(none)"
+        networks = ", ".join(f"{entry['network']}@{entry['area']}" for entry in item["ospf_networks"]) or "(none)"
+        states = ", ".join(f"{state} x{count}" for state, count in sorted(neigh["states"].items())) or "(none)"
+        lines.append(item["router"])
+        socket_hint = proc.get("sockets") or {}
+        systemd_state = proc.get("systemd_state") or "?"
+        vtysh_hint = "ok" if proc.get("vtysh_ok") else ("dead" if proc.get("vtysh_dead") else "?")
+        lines.append(
+            "  FRR: "
+            f"watchfrr={'yes' if proc['watchfrr'] else 'no'}, "
+            f"zebra={'yes' if proc['zebra'] else 'no'}, "
+            f"ospfd={'yes' if proc['ospfd'] else 'no'}, "
+            f"systemd={systemd_state}, "
+            f"zebra_vty={'yes' if socket_hint.get('zebra_vty') else 'no'}, "
+            f"ospfd_vty={'yes' if socket_hint.get('ospfd_vty') else 'no'}, "
+            f"vtysh={vtysh_hint}"
+        )
+        lines.append(f"  Areas (from config): {areas}")
+        lines.append(f"  Networks: {networks}")
+        active_areas = item.get("active_areas") or []
+        if active_areas:
+            area_parts = []
+            for entry in active_areas:
+                adj = entry.get("full_adjacencies")
+                active_ifaces = entry.get("interfaces_active")
+                area_parts.append(
+                    f"{entry['area']}(adj={adj if adj is not None else '?'},"
+                    f"iface={active_ifaces if active_ifaces is not None else '?'})"
+                )
+            lines.append(f"  Active areas (running): {', '.join(area_parts)}")
+        lines.append(f"  Neighbors: {neigh['count']} ({states})")
+        lines.append(f"  OSPF routes: {item['ospf_routes']['count']}")
+        active_interfaces = item.get("active_interfaces") or []
+        if active_interfaces:
+            iface_parts = []
+            for iface in active_interfaces:
+                addr = iface.get("address") or "?"
+                ar = iface.get("area") or "?"
+                nbr = iface.get("neighbor_count")
+                adj = iface.get("adjacent_count")
+                state = iface.get("state") or "?"
+                iface_parts.append(
+                    f"{iface['ifname']}({addr},area={ar},state={state},nbr={nbr},adj={adj})"
+                )
+            lines.append(f"  OSPF interfaces: {', '.join(iface_parts)}")
+        active_errors = [phase for phase, error in errors.items() if error]
+        lines.append(f"  Command errors: {', '.join(active_errors) if active_errors else 'none'}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Get one-pass OSPF coverage across all discovered routers.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    routers = _load_routers(api)
+    snapshots = [_router_snapshot(api, router) for router in routers]
+    if not routers:
+        flags = ["No routers discovered. Ensure the lab is running and the correct LAB_NAME is selected."]
+    else:
+        per_router = [flag for snapshot in snapshots for flag in _flags(snapshot)]
+        cross_router = _area_consistency_flags(snapshots)
+        flags = per_router + cross_router
+    payload = {
+        "lab_name": api.lab.name,
+        "routers": snapshots,
+        "flags": flags,
+    }
+
+    if args.as_json:
+        # Strip the raw command-output strings before emitting JSON. They're
+        # only useful for parser debugging, but each one is 1-3KB; on l-size
+        # topologies the sum balloons the payload past the persistence
+        # threshold and triggers the oversized-output detour.
+        compact = json.loads(json.dumps(payload, default=str))
+        for r in compact.get("routers", []):
+            for k in ("process", "neighbors", "ospf_routes"):
+                if isinstance(r.get(k), dict):
+                    r[k].pop("raw", None)
+        print(json.dumps(compact, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/pressure_sweep.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/pressure_sweep.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python
+"""
+Pressure sweep across service-path devices.
+
+Combines `ps aux --sort=-%cpu`, `/proc/loadavg`, and `ss -s` in a single
+per-device pass to cover these symptoms:
+
+- `load_balancer_overload`    -> stress/stress-ng on LB, >50% CPU daemon, ESTAB spike
+- `web_dos_attack`            -> ab/hey/wrk/hping/httperf on clients, ESTAB/TW spike on server
+- `sender_resource_contention`  -> stress on sender host
+- `sender_application_delay`    -> sleep/tc netem loopback injector on sender
+- `receiver_resource_contention`-> stress on receiver host
+
+One compound exec per device:
+    ===PS=== ps aux --sort=-%cpu | head -12
+    ===LOAD=== cat /proc/loadavg
+    ===SS=== ss -s
+
+Default scope: servers + hosts + routers + switches (everything that can carry a
+per-host fault injector). The helper emits a compact per-device verdict; use
+`--show-clean` to print unflagged rows as well. This keeps the output tight for
+l/m topologies where the service_snapshot dump would otherwise overflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from typing import Any
+
+from network_inventory import _lab_groups, _load_api_class, _resolve_devices
+
+
+DEFAULT_GROUPS = [
+    "hosts",
+    "routers",
+    "switches",
+    "servers",
+    "bmv2_switches",
+    "ovs_switches",
+    "sdn_controllers",
+    "other_devices",
+]
+
+# Per-role expected daemons. Order matters: the first hit is enough; if none
+# of the alternatives appears in the full ps listing we flag `daemon_absent`.
+EXPECTED_DAEMONS: dict[str, tuple[str, ...]] = {
+    "dns": ("named", "bind9", "dnsmasq"),
+    "dhcp": ("dhcpd", "isc-dhcp-server"),
+    "web": ("nginx", "apache2", "httpd", "gunicorn", "uwsgi", "python3"),
+    "load_balancer": ("haproxy", "nginx"),
+    "database": ("mysqld", "mariadbd", "postgres", "redis-server"),
+}
+
+# Process-name fingerprints. First match wins per line.
+PRESSURE_FINGERPRINTS: list[tuple[str, re.Pattern[str], str]] = [
+    ("stress_tool", re.compile(r"\b(stress-ng|stress)\b"), "synthetic CPU/mem pressure injector"),
+    ("http_flood_tool", re.compile(r"\b(ab|hey|wrk|wrk2|httperf|hping3|siege|vegeta|locust)\b"), "HTTP flood / stress client"),
+    ("sleep_injector", re.compile(r"\b(sleep|usleep|tc-netem|nanosleep)\b"), "artificial delay injector"),
+    ("tc_netem", re.compile(r"\btc\b.*\bnetem\b"), "tc netem loopback delay"),
+]
+
+SERVICE_DAEMONS = re.compile(r"\b(nginx|haproxy|apache2|httpd|python3|gunicorn|uwsgi|named|bind9|dnsmasq|dhcpd|isc-dhcp|mysqld|postgres|redis-server)\b")
+
+# Kathara idle ranges (mean baseline observed on unloaded topologies):
+#   loadavg 1min < 0.8, cpu hot threshold for daemons > 40%.
+# A hot user-space daemon or a stress injector is the signal we care about.
+CPU_HOT_THRESHOLD = 50.0
+CPU_DAEMON_THRESHOLD = 40.0
+LOAD_SPIKE_THRESHOLD = 1.0
+
+# ss -s format:
+#   Total: N
+#   TCP:   N (estab K, closed L, orphaned M, timewait O)
+SS_TOTAL_RE = re.compile(r"^\s*Total:\s*(\d+)", re.MULTILINE)
+SS_TCP_ESTAB_RE = re.compile(r"estab\s+(\d+)")
+SS_TCP_TW_RE = re.compile(r"timewait\s+(\d+)")
+SS_TCP_RE = re.compile(r"^\s*TCP:\s*(\d+)\s*\(.*?\)", re.MULTILINE)
+
+# Socket thresholds tuned for Kathara idle (<20 sockets typical on a router).
+TCP_ESTAB_THRESHOLD = 80
+TCP_TW_THRESHOLD = 200
+SOCK_TOTAL_THRESHOLD = 250
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if isinstance(output, list):
+        output = "\n".join(output)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _split_sections(raw: str) -> dict[str, str]:
+    sections: dict[str, str] = {"PS": "", "PSFULL": "", "LOAD": "", "SS": ""}
+    current: str | None = None
+    buffer: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("===") and stripped.endswith("==="):
+            if current is not None:
+                sections[current] = "\n".join(buffer).rstrip()
+            current = stripped.strip("=").strip()
+            buffer = []
+            continue
+        buffer.append(line)
+    if current is not None:
+        sections[current] = "\n".join(buffer).rstrip()
+    return sections
+
+
+def _parse_ps_rows(raw: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in raw.splitlines()[1:]:  # skip header
+        parts = line.split(None, 10)
+        if len(parts) < 11:
+            continue
+        try:
+            pcpu = float(parts[2])
+            pmem = float(parts[3])
+        except ValueError:
+            continue
+        cmd = parts[10].strip()
+        if not cmd:
+            continue
+        argv0 = cmd.split()[0].rsplit("/", 1)[-1]
+        # Filter wrapper/grep/self noise.
+        if argv0 in {"ps", "grep", "head", "sh", "bash", "awk", "sed", "tr"}:
+            continue
+        rows.append(
+            {
+                "user": parts[0],
+                "pid": parts[1],
+                "pcpu": pcpu,
+                "pmem": pmem,
+                "cmd": cmd,
+                "argv0": argv0,
+            }
+        )
+    return rows
+
+
+def _parse_loadavg(raw: str) -> tuple[float | None, float | None, float | None]:
+    stripped = raw.strip().split()
+    if len(stripped) < 3:
+        return None, None, None
+    try:
+        return float(stripped[0]), float(stripped[1]), float(stripped[2])
+    except ValueError:
+        return None, None, None
+
+
+def _parse_ss(raw: str) -> dict[str, int | None]:
+    total = None
+    estab = None
+    timewait = None
+    tcp_total = None
+    match = SS_TOTAL_RE.search(raw)
+    if match:
+        total = int(match.group(1))
+    match = SS_TCP_ESTAB_RE.search(raw)
+    if match:
+        estab = int(match.group(1))
+    match = SS_TCP_TW_RE.search(raw)
+    if match:
+        timewait = int(match.group(1))
+    match = SS_TCP_RE.search(raw)
+    if match:
+        tcp_total = int(match.group(1))
+    return {"total": total, "estab": estab, "timewait": timewait, "tcp_total": tcp_total}
+
+
+def _classify_process(row: dict[str, Any]) -> tuple[str, str] | None:
+    for name, pattern, human in PRESSURE_FINGERPRINTS:
+        if pattern.search(row["cmd"]) or pattern.search(row["argv0"]):
+            return name, human
+    return None
+
+
+def _parse_ps_binaries(raw: str) -> set[str]:
+    """Return the set of argv[0] basenames seen anywhere in the full ps listing.
+
+    Handles common display variants:
+    - `/usr/sbin/nginx -g ...`        -> "nginx"
+    - `nginx: master process ...`     -> "nginx" (strip trailing ":")
+    - `[kworker/0:0]`                 -> "kworker/0:0" (kept for visibility)
+    - `python3 /opt/app/server.py`    -> "python3"
+    """
+    binaries: set[str] = set()
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        first = stripped.split()[0]
+        basename = first.rsplit("/", 1)[-1]
+        # "nginx:" (master/worker process) -> "nginx". Same for any trailing ":".
+        basename = basename.rstrip(":")
+        # Drop obvious shell wrappers and self-probe noise.
+        if basename in {"ps", "grep", "sh", "bash", "head", "awk", "sed", "tr", "echo", "cat"}:
+            continue
+        if basename:
+            binaries.add(basename)
+    return binaries
+
+
+def _daemon_absent_flags(role: str | None, ps_full: set[str]) -> list[str]:
+    """Flag daemon_absent when a server role has no matching daemon in the full ps list.
+
+    We only emit a single flag per role so a single `daemon_absent:dns` line is
+    enough signal for the agent to pivot to `dns-fault-skill`.
+    """
+    if not role:
+        return []
+    expected = EXPECTED_DAEMONS.get(role)
+    if not expected:
+        return []
+    if any(name in ps_full for name in expected):
+        return []
+    return [f"daemon_absent:{role} (expected one of {'|'.join(expected)})"]
+
+
+def _device_snapshot(api: Any, device: str, top_n: int, role: str | None = None) -> dict[str, Any]:
+    command = (
+        f"echo '===PS==='; ps aux --sort=-%cpu --no-headers | head -{top_n}; "
+        "echo '===PSFULL==='; ps -eo cmd --no-headers; "
+        "echo '===LOAD==='; cat /proc/loadavg; "
+        "echo '===SS==='; ss -s"
+    )
+    raw, error = _safe_exec(api, device, command)
+    if error:
+        return {"device": device, "role": role, "error": error, "flags": ["exec_failed"]}
+
+    sections = _split_sections(raw)
+    # ps --no-headers removes the header row -- re-add a fake row so our parser's
+    # "skip header" assumption still works.
+    ps_raw = "HEADER\n" + sections["PS"]
+    rows = _parse_ps_rows(ps_raw)
+    ps_full_binaries = _parse_ps_binaries(sections["PSFULL"])
+    load1, load5, load15 = _parse_loadavg(sections["LOAD"])
+    ss_counts = _parse_ss(sections["SS"])
+
+    pressure_hits: list[dict[str, Any]] = []
+    hot_processes: list[dict[str, Any]] = []
+    hot_daemons: list[dict[str, Any]] = []
+    for row in rows:
+        classification = _classify_process(row)
+        if classification:
+            name, human = classification
+            pressure_hits.append(
+                {
+                    "classification": name,
+                    "reason": human,
+                    "pcpu": row["pcpu"],
+                    "pmem": row["pmem"],
+                    "cmd": row["cmd"],
+                    "user": row["user"],
+                }
+            )
+        if row["pcpu"] >= CPU_HOT_THRESHOLD:
+            hot_processes.append(
+                {
+                    "pcpu": row["pcpu"],
+                    "pmem": row["pmem"],
+                    "cmd": row["cmd"],
+                    "argv0": row["argv0"],
+                }
+            )
+        elif row["pcpu"] >= CPU_DAEMON_THRESHOLD and SERVICE_DAEMONS.search(row["cmd"]):
+            hot_daemons.append(
+                {
+                    "pcpu": row["pcpu"],
+                    "pmem": row["pmem"],
+                    "cmd": row["cmd"],
+                    "argv0": row["argv0"],
+                }
+            )
+
+    flags: list[str] = []
+    seen_classifications: set[str] = set()
+    for hit in pressure_hits:
+        if hit["classification"] not in seen_classifications:
+            flags.append(hit["classification"])
+            seen_classifications.add(hit["classification"])
+    # Fingerprint scan on the FULL ps listing, not just top-N by CPU. Stress
+    # tools that spawn many worker processes (e.g. `stress-ng --cpu 0`
+    # launches one worker per CPU, appearing as `stress-ng-cpu [run]`) can
+    # push the master out of the top-12 CPU sample even though the tool is
+    # active. Matching against PSFULL avoids that sampling gap.
+    for binary in ps_full_binaries:
+        for fp_name, fp_pattern, _ in PRESSURE_FINGERPRINTS:
+            if fp_pattern.search(binary) and fp_name not in seen_classifications:
+                flags.append(fp_name)
+                seen_classifications.add(fp_name)
+                pressure_hits.append({
+                    "classification": fp_name,
+                    "reason": "matched in full ps listing (not in top-CPU sample)",
+                    "pcpu": None,
+                    "pmem": None,
+                    "cmd": binary,
+                    "user": "?",
+                })
+                break
+    if hot_processes:
+        flags.append("cpu_hot_process")
+    if hot_daemons and "cpu_hot_process" not in flags:
+        flags.append("cpu_hot_service_daemon")
+    # NOTE: `/proc/loadavg` inside a Kathara container reflects the Docker
+    # HOST's load, not per-container load — every container on the same host
+    # reads the same number. A "loadavg_spike" flag therefore fires on every
+    # device identically and hides the real per-device signals. We keep the
+    # loadavg value in the payload for context but do NOT flag on it.
+    estab = ss_counts.get("estab")
+    if estab is not None and estab >= TCP_ESTAB_THRESHOLD:
+        flags.append("tcp_estab_spike")
+    timewait = ss_counts.get("timewait")
+    if timewait is not None and timewait >= TCP_TW_THRESHOLD:
+        flags.append("tcp_timewait_spike")
+    total = ss_counts.get("total")
+    if total is not None and total >= SOCK_TOTAL_THRESHOLD:
+        flags.append("socket_total_spike")
+
+    flags.extend(_daemon_absent_flags(role, ps_full_binaries))
+
+    return {
+        "device": device,
+        "role": role,
+        "flags": flags,
+        "pressure_hits": pressure_hits,
+        "hot_processes": hot_processes,
+        "hot_daemons": hot_daemons,
+        "loadavg": {"1m": load1, "5m": load5, "15m": load15},
+        "ss": ss_counts,
+        "top_processes": [
+            {"pcpu": r["pcpu"], "pmem": r["pmem"], "argv0": r["argv0"]}
+            for r in rows[: min(5, len(rows))]
+        ],
+    }
+
+
+def _text_summary(payload: dict[str, Any], show_clean: bool) -> str:
+    lines: list[str] = []
+    displayed_suspects = list(payload["suspect_devices"])
+    displayed_suspects.extend(
+        f"{device} (exec_failed)" for device in payload["exec_failures"]
+    )
+    lines.append("=== PRESSURE SWEEP ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    lines.append(f"Devices scanned: {payload['device_count']}")
+    lines.append(f"Suspect devices: {', '.join(displayed_suspects) if displayed_suspects else 'none'}")
+    if payload["exec_failures"]:
+        lines.append(f"Exec failures: {', '.join(payload['exec_failures'])}")
+        lines.append(
+            "Interpretation: isolated exec_failed is resource/load evidence; host_crash means killed/stopped container."
+        )
+    lines.append("")
+
+    devices = payload["devices"]
+    shown = 0
+    for entry in devices:
+        if not entry["flags"] and not show_clean:
+            continue
+        shown += 1
+        role_tag = f" [role={entry.get('role')}]" if entry.get("role") else ""
+        lines.append(f"{entry['device']}{role_tag}")
+        if entry.get("error"):
+            flags = ", ".join(entry["flags"]) if entry["flags"] else "none"
+            lines.append(f"  Flags: {flags}")
+            lines.append(f"  Error: {entry['error'].splitlines()[0] if entry['error'] else '(unknown)'}")
+            lines.append("")
+            continue
+        flags = ", ".join(entry["flags"]) if entry["flags"] else "none"
+        lines.append(f"  Flags: {flags}")
+        load = entry["loadavg"]
+        load_text = (
+            f"{load['1m']:.2f} / {load['5m']:.2f} / {load['15m']:.2f}"
+            if load["1m"] is not None
+            else "(unavailable)"
+        )
+        lines.append(f"  Loadavg (1/5/15): {load_text}")
+        ss = entry["ss"]
+        ss_text = (
+            f"total={ss.get('total')} tcp={ss.get('tcp_total')} "
+            f"estab={ss.get('estab')} timewait={ss.get('timewait')}"
+        )
+        lines.append(f"  Sockets: {ss_text}")
+        if entry["pressure_hits"]:
+            lines.append("  Pressure processes:")
+            for hit in entry["pressure_hits"][:6]:
+                cpu_text = f"{hit['pcpu']:.1f}%" if isinstance(hit['pcpu'], (int, float)) else "?"
+                mem_text = f"{hit['pmem']:.1f}%" if isinstance(hit['pmem'], (int, float)) else "?"
+                lines.append(
+                    f"    [{hit['classification']}] cpu={cpu_text} mem={mem_text} "
+                    f"user={hit['user']} cmd={hit['cmd'][:80]}"
+                )
+        if entry["hot_processes"]:
+            lines.append("  Hot CPU processes (>= %.0f%%):" % CPU_HOT_THRESHOLD)
+            for hot in entry["hot_processes"][:4]:
+                lines.append(f"    cpu={hot['pcpu']:.1f}% mem={hot['pmem']:.1f}% cmd={hot['cmd'][:80]}")
+        if entry["hot_daemons"] and "cpu_hot_process" not in entry["flags"]:
+            lines.append("  Hot service daemons:")
+            for hot in entry["hot_daemons"][:4]:
+                lines.append(f"    cpu={hot['pcpu']:.1f}% mem={hot['pmem']:.1f}% cmd={hot['cmd'][:80]}")
+        if show_clean and not entry["flags"] and entry["top_processes"]:
+            lines.append("  Top (quiet):")
+            for top in entry["top_processes"]:
+                lines.append(f"    cpu={top['pcpu']:.1f}% mem={top['pmem']:.1f}% {top['argv0']}")
+        lines.append("")
+
+    if shown == 0:
+        lines.append("(all scanned devices clean — no pressure flags)")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pressure / resource sweep across service-path devices.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=[
+            "hosts",
+            "routers",
+            "switches",
+            "servers",
+            "other_devices",
+            "bmv2_switches",
+            "ovs_switches",
+            "sdn_controllers",
+            "all",
+        ],
+        dest="groups",
+    )
+    parser.add_argument("--top", type=int, default=10, help="How many ps rows to return per device.")
+    parser.add_argument("--show-clean", action="store_true", help="Also print devices with no flags.")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    groups = args.groups if args.groups else ([] if args.devices else DEFAULT_GROUPS)
+    devices = _resolve_devices(api, args.devices, groups, expand_neighbors=False)
+    if not devices:
+        parser.error("No devices resolved. Pass --device/--group or run with defaults on a loaded lab.")
+
+    inventory = _lab_groups(api)
+    server_role_by_device: dict[str, str] = {}
+    for role, members in (inventory.get("servers") or {}).items():
+        for member in members:
+            server_role_by_device[member] = role
+
+    entries = [
+        _device_snapshot(api, device, args.top, role=server_role_by_device.get(device))
+        for device in devices
+    ]
+    suspect_devices = [entry["device"] for entry in entries if entry["flags"] and "exec_failed" not in entry["flags"]]
+    exec_failures = [entry["device"] for entry in entries if "exec_failed" in entry["flags"]]
+    triage_suspect_devices = suspect_devices + [
+        f"{device} (exec_failed)" for device in exec_failures
+    ]
+
+    # On l-size topologies the per-device entries explode the JSON payload.
+    # Default: emit only suspect entries (those with flags) — the rest are
+    # summarized as a count. `--show-clean` brings them all back.
+    suspect_entries = [e for e in entries if e["flags"]]
+    clean_count = len(entries) - len(suspect_entries)
+    payload = {
+        "lab_name": api.lab.name,
+        "device_count": len(entries),
+        "suspect_devices": suspect_devices,
+        "exec_failures": exec_failures,
+        "triage_suspect_devices": triage_suspect_devices,
+        "devices": entries if args.show_clean else suspect_entries,
+        "clean_devices_omitted": (not args.show_clean) and clean_count > 0,
+        "clean_count": clean_count,
+    }
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload, show_clean=args.show_clean), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/safe_reachability.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/safe_reachability.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""
+Best-effort reachability helper for cases where MCP get_reachability() fails.
+
+The MCP tool is all-or-nothing: it first runs `ip -j addr` on every host/server
+to learn IPs, and a single non-JSON response aborts the whole tool. This helper
+keeps going, records per-device IP lookup failures, and still returns partial
+reachability coverage for the devices that answered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SRC_ROOT = Path(__file__).resolve().parents[7]
+REPO_ROOT = SRC_ROOT.parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def _load_api_class():
+    try:
+        from nika.service.kathara import KatharaAPIALL as KatharaAPI  # noqa: E402
+    except ModuleNotFoundError as exc:
+        venv_python = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+        raise SystemExit(
+            f"Missing project dependency '{exc.name}'. "
+            f"Run this script with the project interpreter, e.g. '{venv_python}'."
+        ) from exc
+    return KatharaAPI
+
+
+def _host_list(api: Any) -> list[str]:
+    api.load_machines()
+    host_names = list(api.hosts)
+    for servers in api.servers.values():
+        for server in servers:
+            if server not in host_names:
+                host_names.append(server)
+    return sorted(host_names)
+
+
+def _safe_host_ip(api: Any, host_name: str) -> tuple[str | None, str | None]:
+    try:
+        return api.get_host_ip(host_name), None
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+
+
+async def _run_best_effort(api: Any, max_dests: int) -> dict:
+    host_names = _host_list(api)
+
+    host_ips: dict[str, str | None] = {}
+    ip_lookup_failures: list[dict] = []
+    for host_name in host_names:
+        ip, error = _safe_host_ip(api, host_name)
+        host_ips[host_name] = ip
+        if error:
+            ip_lookup_failures.append({"host": host_name, "error": error})
+
+    reachable_hosts = sorted([(name, ip) for name, ip in host_ips.items() if ip])
+    if max_dests <= 0:
+        dst_list = reachable_hosts
+    elif len(reachable_hosts) > max_dests:
+        rng = random.Random(0)
+        dst_list = reachable_hosts.copy()
+        rng.shuffle(dst_list)
+        dst_list = sorted(dst_list[:max_dests])
+    else:
+        dst_list = reachable_hosts
+
+    coroutines = []
+    pairs = []
+    for src_name, _src_ip in reachable_hosts:
+        for dst_name, dst_ip in dst_list:
+            if src_name == dst_name:
+                continue
+            pairs.append((src_name, dst_name, dst_ip))
+            coroutines.append(api._check_ping_success_async(src_name, dst_ip))
+
+    responses = await asyncio.gather(*coroutines) if coroutines else []
+
+    results = []
+    for (src, dst, dst_ip), stats in zip(pairs, responses):
+        if stats is None or not isinstance(stats, dict):
+            stats = {}
+        results.append(
+            {
+                "src": src,
+                "dst": dst,
+                "dst_ip": dst_ip,
+                "tx": stats.get("tx"),
+                "rx": stats.get("rx"),
+                "loss_percent": stats.get("loss_percent"),
+                "time_ms": stats.get("time_ms"),
+                "rtt_avg_ms": stats.get("rtt_avg_ms"),
+                "status": stats.get("status"),
+            }
+        )
+
+    return {
+        "hosts": host_ips,
+        "ip_lookup_failures": ip_lookup_failures,
+        "results": results,
+    }
+
+
+def _summary(payload: dict, max_dests: int) -> str:
+    lines = []
+    hosts = payload["hosts"]
+    failures = payload["ip_lookup_failures"]
+    results = payload["results"]
+    statuses: dict[str, int] = {}
+    for item in results:
+        statuses[item["status"]] = statuses.get(item["status"], 0) + 1
+
+    lines.append("=== SAFE REACHABILITY SUMMARY ===")
+    lines.append("Mode: best-effort sampled fallback after MCP get_reachability() aborted")
+    lines.append(f"Total devices considered: {len(hosts)}")
+    lines.append(f"Devices with IPs: {sum(1 for ip in hosts.values() if ip)}")
+    lines.append(f"IP lookup failures: {len(failures)}")
+    if max_dests <= 0:
+        lines.append("Destination sample: all reachable devices")
+    else:
+        lines.append(f"Destination sample: up to {max_dests} reachable devices")
+    if failures:
+        lines.append("IP lookup failures:")
+        for item in failures:
+            lines.append(f"  - {item['host']}: {item['error']}")
+    lines.append(f"Ping tests run: {len(results)}")
+    if statuses:
+        lines.append(
+            "Ping status counts: " + ", ".join(f"{status}={count}" for status, count in sorted(statuses.items()))
+        )
+    else:
+        lines.append("Ping status counts: none")
+    lines.append("Interpretation:")
+    if failures:
+        lines.append("  - One or more devices failed IP lookup. Treat those devices as direct investigation targets.")
+        lines.append("  - Run pressure_sweep next; if the same running device is `exec_failed`, treat it as resource/load evidence.")
+    else:
+        lines.append("  - No device failed IP lookup in this fallback run, but this DOES NOT clear the original MCP failure.")
+        lines.append("  - The original `get_reachability()` parse failure (e.g. 'Failed to parse `ip -j addr` output')")
+        lines.append("    is itself evidence: SOME device's bulk shell output was malformed when MCP queried.")
+        lines.append("    Most common cause: the device is CPU-exhausted (resource contention / DoS / overload).")
+        lines.append("    Per-host re-queries can succeed when the load eases briefly — that does NOT mean healthy.")
+        lines.append("  - Required next step: run pressure_sweep across hosts + servers + routers to find the")
+        lines.append("    overloaded device. Do NOT submit `is_anomaly=False` based on safe_reachability alone.")
+    lines.append("  - Clean sampled pings do NOT clear the original MCP failure.")
+    lines.append("  - This output is partial coverage only; use it to steer the next checks, not to declare the network healthy.")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Best-effort reachability when MCP get_reachability() aborts.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("--max-dests", type=int, default=2, help="Number of destination devices to sample.")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    payload = asyncio.run(_run_best_effort(api, max_dests=args.max_dests))
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_summary(payload, max_dests=args.max_dests), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/service_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/service_snapshot.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python
+"""
+Compact service-path snapshot helper.
+
+This combines the common "upper-layer canary" checks into one pass:
+- client-side resolvers
+- hostname resolution
+- HTTP timing by URL
+- optional localhost HTTP checks on service devices
+- optional lightweight service-process visibility
+
+Use it for fast DNS/LB/web coverage after the basic path is already understood.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import defaultdict
+from statistics import mean
+from typing import Any
+
+from network_inventory import _lab_groups, _load_api_class, _resolve_devices
+
+
+IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+CURL_FIELD_RE = re.compile(r"(http_code|remote_ip|namelookup|connect|starttransfer|total):([^\s]+)")
+ZONE_A_RECORD_RE = re.compile(r"^([A-Za-z0-9_-]+|@)\s+IN\s+A\s+((?:\d{1,3}\.){3}\d{1,3})\s*$")
+ZONE_BLOCK_RE = re.compile(r'zone\s+"([^"]+)"\s+IN\s*\{.*?file\s+"([^"]+)";', re.IGNORECASE | re.DOTALL)
+SERVICE_PROC_PATTERNS = "nginx|haproxy|apache2|httpd|python3|named|dnsmasq|dhcpd"
+DEFAULT_CLIENT_SAMPLE = 4
+AUTO_FULL_CLIENT_MAX = 12
+AUTO_COMPACT_CLIENT_THRESHOLD = 8
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _parse_nameservers(raw: str) -> list[str]:
+    nameservers = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("nameserver "):
+            nameservers.append(stripped.split(None, 1)[1])
+    return nameservers
+
+
+def _parse_nslookup_addresses(raw: str) -> list[str]:
+    addresses = []
+    after_name = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("Name:"):
+            after_name = True
+            continue
+        if not after_name:
+            continue
+        if stripped.startswith(("Address:", "Addresses:")):
+            tail = stripped.split(":", 1)[1].strip()
+            for match in IP_RE.findall(tail):
+                if match not in addresses:
+                    addresses.append(match)
+            continue
+        if IP_RE.fullmatch(stripped) and stripped not in addresses:
+            addresses.append(stripped)
+    return addresses
+
+
+def _hostname_from_url(url: str) -> str | None:
+    target = url
+    if "://" in target:
+        target = target.split("://", 1)[1]
+    host = target.split("/", 1)[0].split(":", 1)[0].strip()
+    return host or None
+
+
+def _parse_zone_a_records(raw: str) -> list[tuple[str, str]]:
+    records: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        stripped = line.split(";", 1)[0].strip()
+        if not stripped:
+            continue
+        match = ZONE_A_RECORD_RE.match(stripped)
+        if match:
+            records.append((match.group(1), match.group(2)))
+    return records
+
+
+def _reverse_zone(zone: str) -> bool:
+    normalized = zone.lower().rstrip(".")
+    return normalized.endswith(".in-addr.arpa") or normalized.endswith(".ip6.arpa")
+
+
+_BIND_DEFAULT_ZONES = frozenset({"0", "127", "255", "empty", "root"})
+
+
+def _zone_from_path(path: str) -> str | None:
+    filename = path.rsplit("/", 1)[-1].strip()
+    if not filename or filename.endswith(".bak"):
+        return None
+    if filename.startswith("db."):
+        zone = filename[3:]
+    elif filename.endswith(".zone"):
+        zone = filename[:-5]
+    else:
+        return None
+    if not zone or _reverse_zone(zone):
+        return None
+    # Skip bind9 default files (db.0, db.127, db.255, db.empty, db.root).
+    # These are not real service zones; including them makes the helper
+    # manufacture fake hostnames like "web0.127" that bloat output without
+    # adding any diagnostic signal.
+    if zone in _BIND_DEFAULT_ZONES:
+        return None
+    return zone
+
+
+def _bind_zone_sources(api: Any, dns_device: str) -> list[tuple[str, str]]:
+    candidates: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for config_path in (
+        "/etc/bind/named.conf",
+        "/etc/bind/named.conf.local",
+        "/etc/bind/named.conf.default-zones",
+    ):
+        config_raw, config_error = _safe_exec(api, dns_device, f"cat {config_path} 2>/dev/null")
+        if config_error:
+            continue
+        for zone, path in ZONE_BLOCK_RE.findall(config_raw):
+            normalized_zone = zone.strip().rstrip(".")
+            normalized_path = path.strip()
+            if not normalized_zone or not normalized_path or _reverse_zone(normalized_zone):
+                continue
+            key = (normalized_zone, normalized_path)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(key)
+
+    file_list_raw, file_list_error = _safe_exec(api, dns_device, "find /etc/bind -maxdepth 2 -type f 2>/dev/null")
+    if file_list_error:
+        return candidates
+
+    for raw_path in file_list_raw.splitlines():
+        path = raw_path.strip()
+        if not path:
+            continue
+        zone = _zone_from_path(path)
+        if not zone:
+            continue
+        key = (zone, path)
+        if key not in seen:
+            seen.add(key)
+            candidates.append(key)
+
+    return candidates
+
+
+def _curl_command(url: str, times: int) -> str:
+    return (
+        f"for i in $(seq 1 {times}); do "
+        f"curl -sS --connect-timeout 5 --max-time 10 "
+        f"-o /dev/null "
+        f"-w 'http_code:%{{http_code}} remote_ip:%{{remote_ip}} namelookup:%{{time_namelookup}} "
+        f"connect:%{{time_connect}} starttransfer:%{{time_starttransfer}} total:%{{time_total}}\\n' "
+        f"'{url}' || echo 'curl_failed'; "
+        f"done"
+    )
+
+
+def _default_web_service_devices(api: Any) -> list[str]:
+    inventory = _lab_groups(api)
+    devices: list[str] = []
+    devices.extend(sorted(inventory["servers"].get("web", [])))
+    devices.extend(sorted(inventory["servers"].get("load_balancer", [])))
+    return list(dict.fromkeys(devices))
+
+
+def _device_http_url(api: Any, device: str) -> str | None:
+    try:
+        ip = api.get_host_ip(device, with_prefix=False)
+    except TypeError:
+        ip = api.get_host_ip(device)
+    except Exception:
+        return None
+    if not ip:
+        return None
+    if "/" in ip:
+        ip = ip.split("/", 1)[0]
+    return f"http://{ip}/"
+
+
+def _device_ip(api: Any, device: str) -> str | None:
+    try:
+        ip = api.get_host_ip(device, with_prefix=False)
+    except TypeError:
+        ip = api.get_host_ip(device)
+    except Exception:
+        return None
+    if not ip:
+        return None
+    return ip.split("/", 1)[0]
+
+
+def _expected_service_ips(api: Any) -> set[str]:
+    addresses: set[str] = set()
+    for device in _default_web_service_devices(api):
+        if ip := _device_ip(api, device):
+            addresses.add(ip)
+    return addresses
+
+
+def _web_index_from_device(device: str) -> str | None:
+    for pattern in (r"web_server_(\d+)", r"webserver(\d+)", r"web_(\d+)"):
+        match = re.search(pattern, device.lower())
+        if match:
+            return match.group(1)
+    return None
+
+
+def _hostname_tokens(hostname: str) -> tuple[str, list[str]]:
+    label, _, zone = hostname.lower().partition(".")
+    zone_tokens = [token for token in re.split(r"[^a-z0-9]+", zone) if token]
+    return label, zone_tokens
+
+
+def _web_index_from_label(label: str) -> str | None:
+    match = re.match(r"web(\d+)", label)
+    return match.group(1) if match else None
+
+
+def _device_matches_hostname(device: str, hostname: str) -> bool:
+    device_l = device.lower()
+    label, zone_tokens = _hostname_tokens(hostname)
+    label_index = _web_index_from_label(label)
+
+    if "load_balancer" in device_l:
+        return label.startswith("web") and label.endswith("99")
+
+    if "web" not in label or "web" not in device_l:
+        return False
+
+    device_index = _web_index_from_device(device_l)
+    if label_index and device_index and label_index != device_index:
+        return False
+    if label_index and not device_index:
+        return False
+
+    scoped_zone_tokens = [token for token in zone_tokens if token.startswith("pod") or any(ch.isdigit() for ch in token)]
+    if scoped_zone_tokens and not all(token in device_l for token in scoped_zone_tokens):
+        return False
+
+    return True
+
+
+def _expected_addresses_by_hostname(api: Any, hostnames: list[str]) -> dict[str, str]:
+    service_devices = _default_web_service_devices(api)
+    ip_by_device = {device: ip for device in service_devices if (ip := _device_ip(api, device))}
+    expected: dict[str, str] = {}
+
+    for hostname in hostnames:
+        candidates = [device for device in service_devices if _device_matches_hostname(device, hostname)]
+        candidates = [device for device in candidates if device in ip_by_device]
+        if len(candidates) == 1:
+            expected[hostname] = ip_by_device[candidates[0]]
+
+    return expected
+
+
+def _inferred_service_hostnames(api: Any, zones: list[str]) -> list[str]:
+    hostnames: list[str] = []
+    service_devices = _default_web_service_devices(api)
+
+    for zone in zones:
+        normalized_zone = zone.strip().rstrip(".")
+        if not normalized_zone or _reverse_zone(normalized_zone):
+            continue
+        for device in service_devices:
+            device_l = device.lower()
+            if "load_balancer" in device_l:
+                hostname = f"web99.{normalized_zone}"
+            else:
+                web_index = _web_index_from_device(device_l)
+                if web_index is None:
+                    continue
+                hostname = f"web{web_index}.{normalized_zone}"
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+
+    return hostnames
+
+
+def _published_hostnames(api: Any, expected_service_ips: set[str]) -> list[str]:
+    inventory = _lab_groups(api)
+    dns_devices = sorted(inventory["servers"].get("dns", []))
+    hostnames: list[str] = []
+    inferred_hostnames: list[str] = []
+
+    for dns_device in dns_devices:
+        zone_sources = _bind_zone_sources(api, dns_device)
+        zone_names = [zone for zone, _path in zone_sources]
+        for hostname in _inferred_service_hostnames(api, zone_names):
+            if hostname not in inferred_hostnames:
+                inferred_hostnames.append(hostname)
+
+        for zone, path in zone_sources:
+            zone_raw, zone_error = _safe_exec(api, dns_device, f"cat {path} 2>/dev/null")
+            if zone_error:
+                continue
+
+            for label, ip in _parse_zone_a_records(zone_raw):
+                if label == "@":
+                    continue
+                normalized = label.lower()
+                if (expected_service_ips and ip in expected_service_ips) or normalized.startswith("web"):
+                    hostname = f"{label}.{zone}"
+                    if hostname not in hostnames:
+                        hostnames.append(hostname)
+
+    if hostnames:
+        for hostname in inferred_hostnames:
+            if hostname not in hostnames:
+                hostnames.append(hostname)
+        return hostnames
+    return inferred_hostnames
+
+
+def _parse_curl_samples(raw: str) -> tuple[list[dict[str, Any]], list[str]]:
+    samples: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "curl_failed" or stripped.startswith("curl:"):
+            errors.append(stripped)
+            continue
+        fields = dict(CURL_FIELD_RE.findall(stripped))
+        if not fields:
+            errors.append(stripped)
+            continue
+        sample: dict[str, Any] = {"raw": stripped}
+        for key, value in fields.items():
+            if key == "http_code":
+                sample[key] = value
+            else:
+                try:
+                    sample[key] = float(value)
+                except ValueError:
+                    sample[key] = value
+        samples.append(sample)
+    return samples, errors
+
+
+def _http_summary(raw: str) -> dict[str, Any]:
+    samples, errors = _parse_curl_samples(raw)
+    totals = [sample["total"] for sample in samples if isinstance(sample.get("total"), float)]
+    remote_ips = sorted({sample["remote_ip"] for sample in samples if sample.get("remote_ip")})
+    codes = sorted({sample["http_code"] for sample in samples if sample.get("http_code")})
+    return {
+        "samples": samples,
+        "errors": errors,
+        "http_codes": codes,
+        "remote_ips": remote_ips,
+        "avg_total": round(mean(totals), 3) if totals else None,
+    }
+
+
+def _dns_signature(result: dict[str, Any]) -> str:
+    if result["flags"]:
+        return "problem:" + ",".join(sorted(result["flags"]))
+    if result["addresses"]:
+        return "answer:" + ",".join(result["addresses"])
+    return "answer:(none)"
+
+
+def _http_signature(result: dict[str, Any]) -> str:
+    if result.get("flags"):
+        return "problem:" + ",".join(sorted(result["flags"]))
+    code_text = ",".join(result["http_codes"]) if result["http_codes"] else "(none)"
+    remote_text = ",".join(result["remote_ips"]) if result["remote_ips"] else "(none)"
+    return f"codes:{code_text} remote:{remote_text}"
+
+
+def _expected_remote_ip_for_url(
+    url: str,
+    expected_addresses_by_hostname: dict[str, str],
+    expected_service_ips: set[str],
+) -> str | None:
+    hostname = _hostname_from_url(url)
+    if not hostname:
+        return None
+    if IP_RE.fullmatch(hostname):
+        return hostname if hostname in expected_service_ips else None
+    return expected_addresses_by_hostname.get(hostname)
+
+
+def _client_snapshot(
+    api: Any,
+    device: str,
+    hostnames: list[str],
+    urls: list[str],
+    times: int,
+    published_hostnames: set[str],
+    expected_service_ips: set[str],
+    expected_addresses_by_hostname: dict[str, str],
+) -> dict[str, Any]:
+    resolv_raw, resolv_error = _safe_exec(api, device, "cat /etc/resolv.conf 2>/dev/null")
+    nameservers = _parse_nameservers(resolv_raw) if not resolv_error else []
+    dns_results: dict[str, Any] = {}
+    http_results: dict[str, Any] = {}
+    flags: list[str] = []
+
+    for hostname in hostnames:
+        raw, error = _safe_exec(api, device, f"nslookup {hostname} 2>&1")
+        addresses = _parse_nslookup_addresses(raw) if not error else []
+        dns_flags: list[str] = []
+        expected_address = expected_addresses_by_hostname.get(hostname)
+        if error:
+            dns_flags.append("lookup_failed")
+        if not addresses:
+            dns_flags.append("no_addresses")
+        if expected_address and addresses and expected_address not in addresses:
+            dns_flags.append("wrong_address")
+        elif hostname in published_hostnames and addresses and expected_service_ips and not set(addresses).issubset(expected_service_ips):
+            dns_flags.append("unexpected_service_address")
+        dns_results[hostname] = {
+            "addresses": addresses,
+            "error": error,
+            "flags": dns_flags,
+            "raw": raw,
+            "expected_address": expected_address,
+        }
+        if error or not addresses:
+            flags.append(f"dns_problem:{hostname}")
+        if "unexpected_service_address" in dns_flags or "wrong_address" in dns_flags:
+            flags.append(f"dns_unexpected_address:{hostname}")
+
+    for url in urls:
+        expected_remote_ip = _expected_remote_ip_for_url(url, expected_addresses_by_hostname, expected_service_ips)
+        raw, error = _safe_exec(api, device, _curl_command(url, times))
+        summary = _http_summary(raw) if not error else {
+            "samples": [],
+            "errors": [error],
+            "http_codes": [],
+            "remote_ips": [],
+            "avg_total": None,
+        }
+        http_flags: list[str] = []
+        if error or not summary["samples"]:
+            http_flags.append("http_problem")
+        elif any(code == "000" or not code.startswith(("2", "3")) for code in summary["http_codes"]):
+            http_flags.append("http_non_ok")
+        if expected_remote_ip and summary["remote_ips"] and any(ip != expected_remote_ip for ip in summary["remote_ips"]):
+            http_flags.append("wrong_remote_ip")
+        elif not expected_remote_ip and summary["remote_ips"] and expected_service_ips and any(ip not in expected_service_ips for ip in summary["remote_ips"]):
+            http_flags.append("unexpected_service_remote_ip")
+        http_results[url] = {
+            "error": error,
+            "expected_remote_ip": expected_remote_ip,
+            "flags": http_flags,
+            **summary,
+        }
+        if error or not summary["samples"]:
+            flags.append(f"http_problem:{url}")
+        elif any(code == "000" or not code.startswith(("2", "3")) for code in summary["http_codes"]):
+            flags.append(f"http_non_ok:{url}")
+        if "wrong_remote_ip" in http_flags or "unexpected_service_remote_ip" in http_flags:
+            flags.append(f"http_wrong_remote:{url}")
+
+    return {
+        "device": device,
+        "nameservers": nameservers,
+        "resolver_key": ",".join(nameservers) if nameservers else "(none)",
+        "dns": dns_results,
+        "http": http_results,
+        "flags": flags,
+    }
+
+
+def _service_device_snapshot(api: Any, device: str, localhost_url: str, times: int, include_processes: bool) -> dict[str, Any]:
+    http_raw, http_error = _safe_exec(api, device, _curl_command(localhost_url, times))
+    http_summary = _http_summary(http_raw) if not http_error else {"samples": [], "errors": [http_error], "http_codes": [], "avg_total": None}
+    proc_lines: list[str] = []
+    proc_error: str | None = None
+    if include_processes:
+        proc_raw, proc_error = _safe_exec(
+            api,
+            device,
+            f"ps aux | grep -E '{SERVICE_PROC_PATTERNS}' | grep -v grep | head -20",
+        )
+        if not proc_error:
+            proc_lines = [line for line in proc_raw.splitlines() if line.strip()]
+
+    flags: list[str] = []
+    if http_error or not http_summary["samples"]:
+        flags.append("localhost_http_problem")
+    elif any(code == "000" or not code.startswith(("2", "3")) for code in http_summary["http_codes"]):
+        flags.append("localhost_http_non_ok")
+    # `slow_localhost_http`: when localhost HTTP returns 2xx but takes seconds
+    # to complete (or hits curl's --max-time), the application is responding
+    # slowly even though the network and the response code look fine. This is
+    # the in-application-delay fingerprint (e.g. a server that sleeps inside
+    # its handler) — distinct from network or service-down faults. Threshold
+    # is conservative: a localhost call that takes >1s on a Kathara container
+    # is far outside any healthy baseline.
+    avg = http_summary.get("avg_total")
+    if avg is not None and isinstance(avg, (int, float)) and avg >= 1.0:
+        flags.append(f"slow_localhost_http: avg_total={avg:.2f}s")
+    if include_processes and proc_error:
+        flags.append("process_check_failed")
+
+    return {
+        "device": device,
+        "localhost_url": localhost_url,
+        "http": {
+            "error": http_error,
+            **http_summary,
+        },
+        "processes": proc_lines,
+        "process_error": proc_error,
+        "flags": flags,
+    }
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== SERVICE SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    if payload.get("client_sampled"):
+        lines.append(
+            f"Clients scanned: {len(payload['clients'])} "
+            f"(sample of {payload['all_host_count']} hosts)"
+        )
+        lines.append(
+            "Note: sampled client timing is triage only; confirm same-role peer ownership locally before naming the faulty device."
+        )
+    else:
+        lines.append(f"Clients scanned: {len(payload['clients'])}")
+    lines.append(f"Service devices scanned: {len(payload['service_devices'])}")
+    lines.append(f"Hostnames: {', '.join(payload['hostnames']) if payload['hostnames'] else '(none)'}")
+    lines.append(f"URLs: {', '.join(payload['urls']) if payload['urls'] else '(none)'}")
+    if payload["published_hostnames"]:
+        lines.append(f"Published hostnames: {', '.join(payload['published_hostnames'])}")
+    if payload["missing_hostnames"]:
+        lines.append(f"Untested published hostnames: {', '.join(payload['missing_hostnames'])}")
+    if payload["coverage_warnings"]:
+        lines.append(f"Coverage warnings: {', '.join(payload['coverage_warnings'])}")
+    lines.append("")
+
+    if payload["resolver_groups"]:
+        lines.append("Resolver groups:")
+        for resolver_key, devices in payload["resolver_groups"].items():
+            preview = ", ".join(devices[:8])
+            suffix = "" if len(devices) <= 8 else f" ... (+{len(devices) - 8} more)"
+            lines.append(f"- {resolver_key}: {len(devices)} hosts [{preview}{suffix}]")
+        lines.append("")
+
+    if payload["dns_groups"]:
+        lines.append("DNS outcome groups:")
+        for hostname, groups in payload["dns_groups"].items():
+            lines.append(f"- {hostname}:")
+            for signature, devices in groups.items():
+                preview = ", ".join(devices[:8])
+                suffix = "" if len(devices) <= 8 else f" ... (+{len(devices) - 8} more)"
+                lines.append(f"  {signature}: {len(devices)} hosts [{preview}{suffix}]")
+        lines.append("")
+
+    if payload["http_groups"]:
+        lines.append("HTTP outcome groups:")
+        for url, groups in payload["http_groups"].items():
+            lines.append(f"- {url}:")
+            for signature, devices in groups.items():
+                preview = ", ".join(devices[:8])
+                suffix = "" if len(devices) <= 8 else f" ... (+{len(devices) - 8} more)"
+                lines.append(f"  {signature}: {len(devices)} hosts [{preview}{suffix}]")
+        lines.append("")
+
+    lines.append(f"Suspect clients: {', '.join(payload['suspect_clients']) if payload['suspect_clients'] else 'none'}")
+    lines.append("")
+
+    compact = payload.get("compact", False)
+    if compact:
+        trigger = "auto" if payload.get("auto_compact") else "requested"
+        lines.append(
+            f"(compact={trigger}: suppressing per-client/per-service blocks; "
+            "re-run with --full for complete rows)"
+        )
+        lines.append("")
+
+        suspect_set = set(payload["suspect_clients"])
+        suspect_clients = [client for client in payload["clients"] if client["device"] in suspect_set]
+        if suspect_clients:
+            lines.append("Suspect client details:")
+            for client in suspect_clients[:6]:
+                lines.append(f"- {client['device']}: flags={', '.join(client['flags']) or 'none'}")
+            if len(suspect_clients) > 6:
+                lines.append(f"  ... (+{len(suspect_clients) - 6} more suspect clients)")
+            lines.append("")
+
+        for device in payload["service_devices"]:
+            code_text = ", ".join(device["http"]["http_codes"]) if device["http"]["http_codes"] else "(none)"
+            avg_text = (
+                f"{device['http']['avg_total']:.3f}s"
+                if isinstance(device["http"]["avg_total"], float)
+                else "(none)"
+            )
+            flag_text = ", ".join(device["flags"]) if device["flags"] else "none"
+            lines.append(
+                f"Service device {device['device']}: codes={code_text} avg={avg_text} "
+                f"procs={len(device['processes'])} flags={flag_text}"
+            )
+        if payload["service_devices"]:
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+    for client in payload["clients"]:
+        lines.append(client["device"])
+        lines.append(f"  Nameservers: {', '.join(client['nameservers']) if client['nameservers'] else '(none)'}")
+        for hostname, result in client["dns"].items():
+            addr_text = ", ".join(result["addresses"]) if result["addresses"] else "(none)"
+            dns_flags = ", ".join(result["flags"]) if result["flags"] else "none"
+            expected_text = result.get("expected_address") or "(service-pool check)"
+            lines.append(f"  DNS {hostname}: {addr_text} expected={expected_text} flags={dns_flags}")
+        for url, result in client["http"].items():
+            code_text = ", ".join(result["http_codes"]) if result["http_codes"] else "(none)"
+            remote_text = ", ".join(result["remote_ips"]) if result["remote_ips"] else "(none)"
+            avg_text = f"{result['avg_total']:.3f}s" if isinstance(result["avg_total"], float) else "(none)"
+            expected_remote = result.get("expected_remote_ip") or "(service-pool check)"
+            http_flags = ", ".join(result["flags"]) if result["flags"] else "none"
+            lines.append(
+                f"  HTTP {url}: codes={code_text} remote_ips={remote_text} expected_remote={expected_remote} "
+                f"avg_total={avg_text} flags={http_flags}"
+            )
+        lines.append(f"  Flags: {', '.join(client['flags']) if client['flags'] else 'none'}")
+        lines.append("")
+
+    for device in payload["service_devices"]:
+        code_text = ", ".join(device["http"]["http_codes"]) if device["http"]["http_codes"] else "(none)"
+        avg_text = f"{device['http']['avg_total']:.3f}s" if isinstance(device["http"]["avg_total"], float) else "(none)"
+        lines.append(device["device"])
+        lines.append(f"  Localhost HTTP: codes={code_text} avg_total={avg_text}")
+        lines.append(f"  Processes visible: {len(device['processes'])}")
+        lines.append(f"  Flags: {', '.join(device['flags']) if device['flags'] else 'none'}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact service-path snapshot helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("target", nargs="?", help="Optional hostname or full URL shortcut.")
+    parser.add_argument("--client", action="append", default=[], dest="clients")
+    parser.add_argument("--hostname", action="append", default=[], dest="hostnames")
+    parser.add_argument("--url", action="append", default=[], dest="urls")
+    parser.add_argument("--service-device", action="append", default=[], dest="service_devices")
+    parser.add_argument("--localhost-url", default="http://127.0.0.1/")
+    parser.add_argument("--times", type=int, default=2)
+    parser.add_argument("--no-processes", action="store_true")
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Hide per-client and per-service-device blocks; show only groups/suspects/flags.",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Force full per-client and per-service-device blocks, overriding auto-compact.",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    if args.compact and args.full:
+        parser.error("Use either --compact or --full, not both.")
+    if args.target:
+        if args.hostnames or args.urls:
+            parser.error("Use either the positional target or --hostname/--url, not both.")
+        if "://" in args.target:
+            args.urls = [args.target]
+        else:
+            args.hostnames = [args.target]
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    all_hosts = _resolve_devices(api, [], ["hosts"], expand_neighbors=False)
+    default_clients = all_hosts if len(all_hosts) <= AUTO_FULL_CLIENT_MAX else all_hosts[:DEFAULT_CLIENT_SAMPLE]
+    service_devices = list(dict.fromkeys(args.service_devices or _default_web_service_devices(api)))
+    expected_service_ips = _expected_service_ips(api)
+    published_hostnames = _published_hostnames(api, expected_service_ips)
+    hostnames = list(dict.fromkeys(args.hostnames))
+    if not hostnames and not args.urls and published_hostnames:
+        hostnames = list(published_hostnames)
+    expected_addresses_by_hostname = _expected_addresses_by_hostname(api, hostnames)
+    urls = list(dict.fromkeys(args.urls + [f"http://{hostname}/" for hostname in hostnames]))
+    if not hostnames and not args.urls:
+        urls = [device_url for device in service_devices if (device_url := _device_http_url(api, device))]
+    clients = list(dict.fromkeys(args.clients or default_clients))
+    tested_hostnames = {hostname for hostname in hostnames}
+    for url in args.urls:
+        hostname = _hostname_from_url(url)
+        if hostname and not IP_RE.fullmatch(hostname):
+            tested_hostnames.add(hostname)
+    missing_hostnames = [hostname for hostname in published_hostnames if hostname not in tested_hostnames]
+    coverage_warnings: list[str] = []
+    if published_hostnames and not tested_hostnames:
+        coverage_warnings.append("no_hostname_dns_coverage")
+    elif published_hostnames and missing_hostnames:
+        coverage_warnings.append(
+            f"partial_hostname_coverage:{len(tested_hostnames)}/{len(published_hostnames)}"
+        )
+    if not args.clients and len(default_clients) < len(all_hosts):
+        coverage_warnings.append(f"sampled_clients:{len(default_clients)}/{len(all_hosts)}")
+
+    if not urls and not hostnames:
+        parser.error("Provide a target, or ensure the topology exposes web/load_balancer devices.")
+
+    client_records = [
+        _client_snapshot(
+            api,
+            device,
+            hostnames,
+            urls,
+            args.times,
+            set(published_hostnames),
+            expected_service_ips,
+            expected_addresses_by_hostname,
+        )
+        for device in clients
+    ]
+
+    resolver_groups: dict[str, list[str]] = defaultdict(list)
+    for client in client_records:
+        resolver_groups[client["resolver_key"]].append(client["device"])
+
+    dns_groups: dict[str, dict[str, list[str]]] = {}
+    for hostname in hostnames:
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for client in client_records:
+            result = client["dns"].get(hostname)
+            if result:
+                grouped[_dns_signature(result)].append(client["device"])
+        if grouped:
+            dns_groups[hostname] = {key: sorted(value) for key, value in sorted(grouped.items())}
+
+    http_groups: dict[str, dict[str, list[str]]] = {}
+    for url in urls:
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for client in client_records:
+            result = client["http"].get(url)
+            if result:
+                grouped[_http_signature(result)].append(client["device"])
+        if grouped:
+            http_groups[url] = {key: sorted(value) for key, value in sorted(grouped.items())}
+
+    suspect_clients = sorted({client["device"] for client in client_records if client["flags"]})
+
+    auto_compact = len(client_records) > AUTO_COMPACT_CLIENT_THRESHOLD
+    if args.full:
+        compact = False
+    elif args.compact:
+        compact = True
+    else:
+        compact = auto_compact
+
+    suspect_set = set(suspect_clients)
+    full_clients = client_records
+    # In compact mode, only emit suspect clients in the JSON payload too —
+    # the per-client per-URL block on l-size topologies (16+ clients × N
+    # URLs) is the main JSON-bloat source for this helper.
+    json_clients = full_clients if not compact else [
+        c for c in full_clients if c["device"] in suspect_set
+    ]
+    payload = {
+        "lab_name": api.lab.name,
+        "hostnames": hostnames,
+        "urls": urls,
+        "published_hostnames": published_hostnames,
+        "missing_hostnames": missing_hostnames,
+        "coverage_warnings": coverage_warnings,
+        "all_host_count": len(all_hosts),
+        "client_sampled": not args.clients and len(default_clients) < len(all_hosts),
+        "resolver_groups": {key: sorted(value) for key, value in sorted(resolver_groups.items())},
+        "dns_groups": dns_groups,
+        "http_groups": http_groups,
+        "suspect_clients": suspect_clients,
+        "clients": full_clients,  # text summary may need all
+        "service_devices": [
+            _service_device_snapshot(api, device, args.localhost_url, args.times, include_processes=not args.no_processes)
+            for device in service_devices
+        ],
+        "compact": compact,
+        "auto_compact": auto_compact and not args.full,
+    }
+    if args.as_json:
+        # Emit a compact JSON view: drop clean client records when in compact
+        # mode so the payload stays parseable.
+        json_payload = dict(payload)
+        json_payload["clients"] = json_clients
+        json_payload["clean_clients_omitted"] = compact and len(json_clients) < len(full_clients)
+        print(json.dumps(json_payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/tc_snapshot.py
+++ b/src/agent/community/sade/.claude/skills/diagnosis-methodology-skill/scripts/tc_snapshot.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python
+"""
+Compact traffic-control coverage helper.
+
+This combines the most common quiet-throughput checks into one pass:
+- active interface discovery
+- qdisc inspection across the scanned devices
+- compact `tc -s` previews only for interfaces with non-default qdisc stacks
+
+Use it when reachability and small HTTP checks look healthy but throughput,
+latency variation, or shaping is still plausible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from typing import Any
+
+from network_inventory import _load_api_class, _parse_l2_inventory, _resolve_devices
+
+DEFAULT_GROUPS = [
+    "hosts",
+    "routers",
+    "switches",
+    "servers",
+    "bmv2_switches",
+    "ovs_switches",
+    "sdn_controllers",
+    "other_devices",
+]
+DEFAULT_QDISC_KINDS = {"fq_codel", "noqueue", "mq", "pfifo_fast", "pfifo", "bfifo"}
+QDISC_RE = re.compile(
+    r"^qdisc\s+(?P<kind>\S+)\s+(?P<handle>\S+):(?:\s+dev\s+(?P<ifname>\S+))?\s+(?P<rest>.+)$"
+)
+PARENT_RE = re.compile(r"\bparent\s+(?P<parent>\S+)\b")
+
+
+def _command_failed(output: str) -> bool:
+    return output.startswith("[TIMEOUT]") or output.startswith("Machine ") or "not found in lab" in output
+
+
+def _safe_exec(api: Any, device: str, command: str) -> tuple[str, str | None]:
+    output = api.exec_cmd(device, command)
+    if isinstance(output, list):
+        output = "\n".join(output)
+    if _command_failed(output):
+        return output, output
+    return output, None
+
+
+def _is_selected_interface(interface: dict[str, Any], include_down: bool) -> bool:
+    if interface.get("ifname") == "lo":
+        return False
+    if include_down:
+        return True
+
+    operstate = (interface.get("operstate") or "").upper()
+    flags = {flag.upper() for flag in interface.get("flags", [])}
+    return operstate in {"UP", "UNKNOWN"} or "UP" in flags
+
+
+def _parse_qdisc_entries(raw: str) -> dict[str, list[dict[str, str]]]:
+    by_interface: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("qdisc "):
+            continue
+        match = QDISC_RE.match(stripped)
+        if not match:
+            continue
+
+        rest = match.group("rest")
+        ifname = match.group("ifname")
+        if not ifname:
+            continue
+
+        role = "root" if " root " in f" {rest} " else "child" if " parent " in f" {rest} " else "other"
+        parent_match = PARENT_RE.search(rest)
+        by_interface[ifname].append(
+            {
+                "kind": match.group("kind"),
+                "handle": match.group("handle"),
+                "ifname": ifname,
+                "role": role,
+                "parent": parent_match.group("parent") if parent_match else "",
+                "raw": stripped,
+            }
+        )
+    return by_interface
+
+
+def _unique_kinds(entries: list[dict[str, str]]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for entry in entries:
+        kind = entry["kind"]
+        if kind in seen:
+            continue
+        seen.add(kind)
+        ordered.append(kind)
+    return ordered
+
+
+def _classify_qdisc(entries: list[dict[str, str]]) -> dict[str, Any]:
+    if not entries:
+        return {
+            "flagged": True,
+            "classification": "no_qdisc_visible",
+            "kind_chain": "(none)",
+        }
+
+    root_kinds = [entry["kind"] for entry in entries if entry["role"] == "root"]
+    child_kinds = [entry["kind"] for entry in entries if entry["role"] == "child"]
+    all_kinds = _unique_kinds(entries)
+    kind_set = set(all_kinds)
+
+    if "netem" in root_kinds and "tbf" in child_kinds:
+        classification = "incast_traffic_network_limitation"
+        flagged = True
+    elif "tbf" in root_kinds:
+        classification = "link_bandwidth_throttling"
+        flagged = True
+    elif kind_set and kind_set.issubset(DEFAULT_QDISC_KINDS):
+        classification = "default"
+        flagged = False
+    elif "tbf" in kind_set:
+        classification = "tbf_present"
+        flagged = True
+    elif "netem" in kind_set:
+        classification = "netem_present"
+        flagged = True
+    else:
+        classification = "nondefault_tc"
+        flagged = True
+
+    return {
+        "flagged": flagged,
+        "classification": classification,
+        "kind_chain": ", ".join(all_kinds) if all_kinds else "(none)",
+    }
+
+
+def _stats_preview(raw: str, max_lines: int = 6) -> list[str]:
+    preview: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("qdisc ") or stripped.startswith("Sent ") or stripped.startswith("backlog "):
+            preview.append(stripped)
+        if len(preview) >= max_lines:
+            break
+    return preview
+
+
+def _device_snapshot(
+    api: Any,
+    device: str,
+    *,
+    include_down: bool,
+    include_bridges: bool,
+    stats_for_flagged: bool,
+) -> dict[str, Any]:
+    try:
+        interfaces = _parse_l2_inventory(api, device, include_loopback=False, include_bridges=include_bridges)
+    except Exception as exc:  # pragma: no cover - depends on live lab state
+        return {
+            "device": device,
+            "interfaces": [],
+            "device_error": str(exc),
+        }
+
+    selected_interfaces = [interface for interface in interfaces if _is_selected_interface(interface, include_down)]
+    if not selected_interfaces:
+        return {
+            "device": device,
+            "interfaces": [],
+            "device_error": None,
+        }
+
+    qdisc_raw, qdisc_error = _safe_exec(api, device, "tc qdisc show 2>&1")
+    qdisc_by_interface = _parse_qdisc_entries(qdisc_raw) if not qdisc_error else {}
+    interface_entries: list[dict[str, Any]] = []
+
+    for interface in selected_interfaces:
+        ifname = interface["ifname"]
+        entries = qdisc_by_interface.get(ifname, [])
+        analysis = _classify_qdisc(entries)
+        stats_lines: list[str] = []
+        stats_error: str | None = None
+        if analysis["flagged"] and stats_for_flagged and not qdisc_error and entries:
+            stats_raw, stats_error = _safe_exec(api, device, f"tc -s qdisc show dev {ifname} 2>&1")
+            if not stats_error:
+                stats_lines = _stats_preview(stats_raw)
+
+        interface_entries.append(
+            {
+                "ifname": ifname,
+                "operstate": interface.get("operstate"),
+                "mac": interface.get("mac"),
+                "ipv4": interface.get("ipv4", []),
+                "qdisc_error": qdisc_error,
+                "classification": analysis["classification"],
+                "flagged": analysis["flagged"],
+                "kind_chain": analysis["kind_chain"],
+                "qdisc_lines": [entry["raw"] for entry in entries],
+                "stats_lines": stats_lines,
+                "stats_error": stats_error,
+            }
+        )
+
+    return {
+        "device": device,
+        "interfaces": interface_entries,
+        "device_error": qdisc_error,
+    }
+
+
+def _text_summary(payload: dict[str, Any]) -> str:
+    lines = []
+    lines.append("=== TC SNAPSHOT ===")
+    lines.append(f"Lab: {payload['lab_name']}")
+    if payload["scope"]:
+        lines.append(f"Scope: {', '.join(payload['scope'])}")
+    lines.append(f"Devices scanned: {payload['device_count']}")
+    lines.append(f"Interfaces inspected: {payload['interface_count']}")
+    lines.append(f"Flagged interfaces: {payload['flagged_count']}")
+    lines.append(f"Device errors: {len(payload['device_errors'])}")
+
+    if payload["default_profiles"]:
+        lines.append("Clean qdisc profiles:")
+        for profile, count in payload["default_profiles"]:
+            lines.append(f"  - {profile}: {count}")
+
+    if payload["flagged_categories"]:
+        lines.append("Flagged categories:")
+        for category, count in payload["flagged_categories"]:
+            lines.append(f"  - {category}: {count}")
+
+    if payload["device_errors"]:
+        lines.append("Device errors:")
+        for item in payload["device_errors"]:
+            lines.append(f"  - {item['device']}: {item['error']}")
+
+    if payload["flagged_interfaces"]:
+        lines.append("Flagged interfaces:")
+        for item in payload["flagged_interfaces"]:
+            lines.append(
+                f"  - {item['device']} {item['ifname']}: "
+                f"{item['classification']} | qdiscs={item['kind_chain']}"
+            )
+            for qdisc_line in item["qdisc_lines"]:
+                lines.append(f"    {qdisc_line}")
+            for stats_line in item["stats_lines"]:
+                lines.append(f"    {stats_line}")
+            if item["stats_error"]:
+                lines.append(f"    stats_error: {item['stats_error']}")
+    elif payload["clean_interfaces"]:
+        lines.append("Clean interface profiles:")
+        for item in payload["clean_interfaces"]:
+            lines.append(f"  - {item['device']} {item['ifname']}: {item['kind_chain']}")
+    else:
+        lines.append("Flagged interfaces: none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compact traffic-control coverage helper.")
+    parser.add_argument("--lab", default=os.getenv("LAB_NAME", "ospf_enterprise_dhcp"))
+    parser.add_argument("device", nargs="?", help="Optional single-device shortcut.")
+    parser.add_argument("--device", action="append", default=[], dest="devices")
+    parser.add_argument(
+        "--group",
+        action="append",
+        default=[],
+        choices=[
+            "hosts",
+            "routers",
+            "switches",
+            "servers",
+            "other_devices",
+            "bmv2_switches",
+            "ovs_switches",
+            "sdn_controllers",
+            "all",
+        ],
+        dest="groups",
+    )
+    parser.add_argument("--include-bridges", action="store_true")
+    parser.add_argument("--include-down", action="store_true")
+    parser.add_argument("--show-clean", action="store_true")
+    parser.add_argument("--no-stats", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    requested_devices = list(args.devices)
+    if args.device:
+        requested_devices.append(args.device)
+    groups = args.groups if args.groups else ([] if requested_devices else DEFAULT_GROUPS)
+
+    KatharaAPI = _load_api_class()
+    api = KatharaAPI(lab_name=args.lab)
+    devices = _resolve_devices(api, requested_devices, groups, expand_neighbors=False)
+    payload_devices = [
+        _device_snapshot(
+            api,
+            device,
+            include_down=args.include_down,
+            include_bridges=args.include_bridges,
+            stats_for_flagged=not args.no_stats,
+        )
+        for device in devices
+    ]
+
+    flagged_interfaces: list[dict[str, Any]] = []
+    clean_interfaces: list[dict[str, Any]] = []
+    flagged_categories: Counter[str] = Counter()
+    default_profiles: Counter[str] = Counter()
+    device_errors: list[dict[str, str]] = []
+    interface_count = 0
+
+    for device_entry in payload_devices:
+        if device_entry.get("device_error"):
+            device_errors.append({"device": device_entry["device"], "error": device_entry["device_error"]})
+        for interface_entry in device_entry["interfaces"]:
+            interface_count += 1
+            item = {"device": device_entry["device"], **interface_entry}
+            if interface_entry["flagged"]:
+                flagged_interfaces.append(item)
+                flagged_categories[interface_entry["classification"]] += 1
+            else:
+                clean_interfaces.append(item)
+                default_profiles[interface_entry["kind_chain"]] += 1
+
+    show_clean = args.show_clean or bool(requested_devices)
+    # Drop the per-device raw payload from JSON unless --show-clean is set;
+    # on l-size topologies the full `devices` array is the main bloat source.
+    payload = {
+        "lab_name": api.lab.name,
+        "scope": requested_devices if requested_devices else groups,
+        "device_count": len(devices),
+        "interface_count": interface_count,
+        "flagged_count": len(flagged_interfaces),
+        "flagged_categories": sorted(flagged_categories.items()),
+        "default_profiles": sorted(default_profiles.items()),
+        "device_errors": device_errors,
+        "flagged_interfaces": flagged_interfaces,
+        "clean_interfaces": clean_interfaces if show_clean else [],
+        "devices": payload_devices if show_clean else [],
+        "devices_omitted": (not show_clean) and bool(payload_devices),
+    }
+
+    if args.as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_text_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/.claude/skills/dns-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/dns-fault-skill/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: dns-fault-skill
+description: Identify DNS server-side faults — wrong record, daemon down, port 53 filtered, or injected lookup latency. Use when hostname-based access fails or is slow while direct-IP access to the same target works.
+---
+
+# DNS Server-Side Faults
+
+## What These Faults Mean
+
+- `dns_record_error`: the DNS server answers, but the record points to an IP the topology never declared.
+- `dns_service_down`: the DNS daemon (`named`) is absent or not listening on port 53, so the server cannot answer queries.
+- `dns_port_blocked`: the daemon is alive but `nft`/`iptables` drops port 53 traffic.
+- `dns_lookup_latency`: a `tc` qdisc (`netem delay` or `tbf`) on the DNS server's egress adds large per-query latency while record/listener/firewall all look healthy.
+
+## Exit conditions
+
+- If only one host's `/etc/resolv.conf` differs from peers and the DNS server itself is healthy, exit to `host-ip-skill` and submit `host_incorrect_dns` there. That RCA is NOT owned by this skill.
+- If `dhcpd.conf` on the DHCP server pushes the wrong nameserver and affected hosts show that exact wrong resolver, exit to `dhcp-fault-skill` for `dhcp_spoofed_dns`.
+
+## Guardrails
+
+- Do not call `dns_service_down` from query timeout alone; the timeout could be a firewall block or a qdisc delay. Check process, listener, AND firewall before naming `dns_service_down`.
+- `dns_lookup_latency` needs the actual qdisc evidence on the DNS server's egress interface. High latency alone is not a fingerprint.
+- One healthy client does not clear a server-side DNS fault.

--- a/src/agent/community/sade/.claude/skills/host-crash-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/host-crash-skill/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: host-crash-skill
+description: Identify a device that has been killed, stopped, or removed from the topology. Use when a device is completely unresponsive — ICMP fails, shell never opens, no service response — while same-role peers stay clean.
+---
+
+# host_crash
+
+## Fingerprint (all three must be true → submit)
+
+- ICMP to the device's known IP fails. Look up the IP via a peer or `safe_reachability`; do not rely on a name that the device itself resolves.
+- Shell on the device times out or never opens — `exec_shell`, `infra_sweep exec_failed`, and `safe_reachability` all fail on that device.
+- Same-role peer baseline stays clean. Other hosts/servers of the same kind remain reachable, the routing fabric is healthy, and no widespread cascade is in play.
+
+All three must hold. Any partial response rules out `host_crash`.
+
+## Submit
+
+- `is_anomaly=True`
+- `root_cause_name=["host_crash"]`
+- `faulty_devices=["<device>"]`
+
+## Not load_balancer_overload
+
+If the unresponsive device is the load balancer and it still answers ICMP, localhost HTTP, or any partial VIP probe, that is probably `load_balancer_overload`. Use `load-balancer-skill`.
+
+## Not sender/receiver_resource_contention
+
+An isolated `exec_failed`/timeout on one web/app server or one client, while ICMP still answers or same-role peers are otherwise clean, is resource contention — not crash. Use `resource-contention-skill`. `host_crash` requires full silence and a clean same-role baseline.
+
+## Not upstream cascade
+
+If many same-role devices are unreachable together, or the routing/control-plane fabric is broken, the cause is upstream (link, ACL, OSPF/BGP, DHCP relay). Rerun the matching broad-search helper before submitting `host_crash`.

--- a/src/agent/community/sade/.claude/skills/host-ip-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/host-ip-skill/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: host-ip-skill
+description: Identify per-host L2/L3 identity faults — IP conflict, wrong IP, wrong gateway, wrong netmask, missing IP, host-local resolv.conf misconfig, static `arp -s` poisoning. Use when one host (or a small minority) shows an addressing anomaly its same-subnet peers do not share.
+---
+
+# Host IP Faults
+
+## Rule out link first
+
+Transient or intermittent host-identity symptoms — short lease, lost default route, missing IP, conflicting interface-state readings between probes — frequently originate from an unstable access link, not from host configuration. Confirm the access interface is present and stable before classifying anything in this family. If the interface is currently DOWN or missing, or is actively flapping, the case belongs to `link-fault-skill`, not here.
+
+A low carrier-changes counter alone is not a link fault — startup history can produce a small number of transitions on a currently healthy link. Use it as supporting context, not as a family switch.
+
+## Distinctive-evidence requirement
+
+The host's evidence must be distinctive — same-subnet peers do not share it. If many hosts share the same anomaly, the cause is upstream (routing / DHCP / ACL / control plane) and this skill does not own it; see Disambiguation.
+
+## Cross-family checks for missing IP
+
+When a host has no IPv4 address and the access interface is UP and stable, more than one upstream cause produces the same symptom. Before submitting a host-side missing-IP fault, rule out: a duplicate MAC against the gateway or another switch, a broken routing / control-plane path to the DHCP server, and an ARP ACL drop or empty (`<incomplete>`) gateway neighbor entry on the host. If any of those fires, the owning family is elsewhere.
+
+## Submit on match
+
+When direct evidence is sufficient (link ruled out, peers don't share the symptom, and the cross-family checks above are clear for missing-IP cases), submit. Do not chain extra probes once the family is confirmed.
+
+## Disambiguation
+
+- **Subnet-wide vs per-host.** If many hosts share the same anomaly, the cause is upstream. Treat this skill as not owning the case and look at routing / DHCP / ACL / control plane.
+- **Wrong gateway: host vs DHCP server.** If the DHCP server's config pushes the same wrong gateway value the host has, that's a DHCP fault (`dhcp-fault-skill`), not this one.
+- **Missing IP vs link instability.** A transient no-IP reading during link flap is not a host-side missing-IP fault. Require the access interface to be UP and the no-IP state to persist across probes before naming a host-side fault.
+- **Missing IP vs ARP drop.** An ARP-filter drop rule or an empty / `<incomplete>` gateway neighbor entry breaks DHCP lease renewal and produces the same symptom as a host-side missing IP. Check the host's neighbor table and ruleset before submitting; if either fires, the owning family is `acl-skill`.
+- **ARP poisoning vs ARP ACL.** An empty / `<incomplete>` / zero-MAC gateway entry leans toward `acl-skill` (ARP filtered). A *populated* entry whose MAC does not match the gateway router's real interface MAC, or any entry carrying a static / permanent flag, is ARP cache poisoning. A populated entry matching the gateway router's real MAC is healthy.
+- **Host-local DNS misconfig.** A healthy DNS server does not clear a host-side resolver fault; the symptom is the host's resolver differing from same-subnet peers.

--- a/src/agent/community/sade/.claude/skills/link-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/link-fault-skill/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: link-fault-skill
+description: Identify link_flap, link_down, and link_detach faults. Use when an interface is DOWN, missing, detached, repeatedly flapping, or shows network-down history.
+---
+
+# Link Faults
+
+## What These Faults Mean
+
+- `link_detach`: the expected interface is missing entirely from the device.
+- `link_down`: the interface exists but is down and there is no evidence it is intentionally flapping.
+- `link_flap`: the interface repeatedly transitions down and up, so the device may look healthy by the time it is inspected.
+
+## Leading Signals
+
+- Interface state (`ip link show`) proves whether the interface exists and whether it is up right now.
+- Direct evidence of repeated link transitions — climbing carrier-changes, kernel link events, or any agent on the host repeatedly toggling the interface — is stronger than transient DHCP fallout alone.
+- Link history (startup logs, `dhcp_link_history.py`) is important when the interface has already recovered by the time you inspect it.
+
+## Exact Calls
+
+- `get_host_net_config(host_name="<host>")`
+- `exec_shell(host_name="<host>", command="ip link show")`
+- Check for repeated link transitions: interface counters (`ip -s link show <iface>`), kernel link events (`dmesg | grep -i link`), or any process or scheduled job repeatedly toggling the interface.
+- `exec_shell(host_name="<host>", command="tail -100 /var/log/startup.log")`
+- `python diagnosis-methodology-skill/scripts/dhcp_link_history.py <host>`
+
+## Submit on match
+
+When direct evidence (current interface state, repeated link transitions, or startup-log link history) is sufficient to identify the fault, submit. Do not chain extra probes once the family is confirmed.
+
+## Recovered Interface Rule
+
+- If the interface is already back UP when you inspect it, history can keep the link family alive — but only with direct evidence of past instability, not inference from downstream symptoms.
+- Submit `link_flap` only with direct evidence of repeated transitions (climbing carrier-changes over a short window, kernel link events, or an active agent toggling the interface). A single non-zero `carrier_changes` value on its own is not enough — small counts can be normal startup history.
+- If the interface recovered but there is no evidence of repeated flap, prefer `link_down` only when startup or DHCP history contains direct link errors (such as `Network is down`), or when the interface is observed DOWN on one probe and UP on a later probe.
+- If the host access interface is UP but the host briefly lost IP or default route, check link history once before leaving the link family.
+
+## Cross-Family Guardrails
+
+- If the host access interface is present and UP but the host lacks IP or default route, do not switch immediately. First rule out an active or recently-recovered link fault using interface counters or kernel link history. If the link is steady and the host's missing-IP / wrong-config state is distinctive (same-subnet peers don't share it), the case belongs to `host-ip-skill`.
+- Do not let one no-route snapshot outrank direct evidence of repeated link transitions.
+- A later recovered DHCP lease does not by itself reclassify a host-side missing-IP fault as a link fault.
+- Never submit `link_down` without first checking whether the interface is flapping rather than statically down.

--- a/src/agent/community/sade/.claude/skills/load-balancer-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/load-balancer-skill/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: load-balancer-skill
+description: Identify load-balancer-side service faults. Use when the topology includes a load balancer (nginx, HAProxy) and the LB itself shows pressure — slow VIP, command or helper timeouts on the LB, failed IP lookups, or CPU/socket spikes while backends are healthy.
+---
+
+# load_balancer_overload
+
+## Fingerprint (any 2 → submit)
+
+- ICMP to the LB known IP succeeds. Use an IP from `safe_reachability` or a host's resolver; do not rely on a name lookup that itself depends on the LB.
+- HTTP/VIP probe from a client fails, times out, or returns an empty body.
+- Shell command on the LB times out — `exec_shell` hangs, `infra_sweep` reports `exec_failed` on the LB, `safe_reachability` IP lookup fails on the LB, or `pressure_sweep` times out on the LB.
+
+## Submit
+
+- `is_anomaly=True`
+- `root_cause_name=["load_balancer_overload"]`
+- `faulty_devices=["<load_balancer_device_name>"]`
+
+One direct probe to confirm the pattern is enough. Do not chain extra investigations once two fingerprints match.
+
+## Not host_crash
+
+`host_crash` means the container was killed/stopped/removed: no ICMP, no response of any kind, and the same-role baseline stays clean. Any partial LB response — ICMP reply, partial HTTP, localhost nginx answer — rules out `host_crash`.
+
+## Not web_dos_attack
+
+Switch only if a running HTTP flood tool (`ab`, `wrk`, `hping3`, `hey`, `httperf`, `siege`, `vegeta`, `locust`) is found on an attacker host and targets the LB/VIP. Probe-traffic log entries are not flood evidence.
+
+## Not resource-contention-skill
+
+Stay here when the LB itself is the flagged device. Route to `resource-contention-skill` only when the direct pressure signal is on a non-LB backend or client and the LB stays clean.

--- a/src/agent/community/sade/.claude/skills/mac-address-conflict-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/mac-address-conflict-skill/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: mac-address-conflict-skill
+description: Identify duplicate hardware (MAC) addresses on the same network segment. Use when a helper surfaces a concrete duplicate `link/ether` value or an ARP entry that flips between two MACs for one IP.
+---
+
+# MAC Address Conflict
+
+## What This Fault Means
+
+- `mac_address_conflict` means two different devices present the same Layer 2 hardware identity on the network.
+- This can make ARP, switching, and control-plane behavior unstable or intermittent even when small ping samples sometimes pass.
+
+## Leading Signals
+
+- Two devices show the exact same `link/ether` MAC.
+- Witness ARP data flips one MAC across multiple IPs, and direct device-side MAC collection confirms the duplicate.
+- The decisive proof is the duplicate MAC itself, not only the downstream symptoms.
+
+## Exact Calls
+
+- `python diagnosis-methodology-skill/scripts/l2_snapshot.py`
+- `python diagnosis-methodology-skill/scripts/network_inventory.py summary`
+- `python diagnosis-methodology-skill/scripts/network_inventory.py connected <device>`
+- `exec_shell(host_name="<host>", command="ip link show")`
+- `exec_shell(host_name="<witness_host>", command="arp -n")`
+
+## Required Tool Usage
+
+- `l2_snapshot` is the MAC-inventory and duplicate-MAC proof tool; `network_inventory` only exposes topology views (`summary`, `connected`).
+- Direct `link/ether` comparison is stronger than ARP-table symptoms.
+
+## Sweep Rules
+
+- If the affected segment is unknown, start with the broad MAC inventory helper.
+- The default MAC and L2 sweeps must include server-side devices (for example load balancers and application servers), not only hosts, routers, and switches.
+- Compare one full Layer 2 domain at a time: hosts, gateway, switch/bridge, then adjacent infrastructure if needed.
+- Clean L3-L7 checks increase the priority of direct MAC comparison; they do not clear this fault.
+
+## Guardrails
+
+- Do not rule this out from sampled reachability alone.
+- Do not rely on ARP tables alone when direct MAC comparison is available.
+- Bridge membership such as `ethX -> br0` is topology information, not MAC-conflict proof by itself.
+- Identical `link/ether` values on two different routers or hosts are a real L2 identity fault, not a measurement artifact.

--- a/src/agent/community/sade/.claude/skills/ospf-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/ospf-fault-skill/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ospf-fault-skill
+description: Distinguish OSPF and FRR routing faults - ospf_neighbor_missing, ospf_area_misconfiguration, ospf_acl_block, and frr_service_down. Use when reachability failures follow routing paths, OSPF neighbors are missing, or routing daemons are suspect.
+---
+
+# OSPF And FRR Faults
+
+## What These Faults Mean
+
+- `frr_service_down`: the routing daemon stack is not running, even if config files still look valid.
+- `ospf_neighbor_missing`: the router is not correctly participating in OSPF adjacency or route origination, often because expected `network` statements are missing.
+- `ospf_area_misconfiguration`: a specific adjacency-carrying link is placed in the wrong OSPF area relative to peer or topology expectations.
+- `ospf_acl_block`: router firewall policy blocks OSPF packets even though interfaces and config may look otherwise healthy.
+
+## Leading Signals
+
+- One router or one routed segment loses paths while interfaces remain present.
+- `show ip ospf neighbor` and `show running-config` prove adjacency and area state directly.
+- FRR process checks separate dead control plane from bad config.
+
+## Exact Calls
+
+- `exec_shell(host_name="<router>", command="ps aux | grep -E 'zebra|ospfd|watchfrr' | grep -v grep")`
+- `exec_shell(host_name="<router>", command="vtysh -c 'show ip ospf neighbor'")`
+- `exec_shell(host_name="<router>", command="vtysh -c 'show running-config'")`
+- `exec_shell(host_name="<router>", command="nft list ruleset")`
+- `frr_show_running_config(router_name="<router>")`
+- `frr_show_ip_route(router_name="<router>")`
+
+## Required Tool Usage
+
+- FRR MCP tools use `router_name`, not `host_name`.
+- If you are unsure of the FRR helper schema, use `exec_shell(host_name="<router>", command="vtysh -c '...'")`.
+- `frr_show_running_config` and `frr_show_ip_route` are secondary evidence only; they can look healthy when FRR is down.
+
+## One-Pass Coverage
+
+- `python diagnosis-methodology-skill/scripts/ospf_snapshot.py`
+
+## Submit on match
+
+When direct evidence on a router (process state, OSPF config, area assignment, or `nft` rule) is sufficient to identify the fault, submit. Do not chain extra probes once the family is confirmed.
+
+## Guardrails
+
+- Do not infer `ospf_area_misconfiguration` from LSDB differences alone.
+- You need direct config evidence for the wrong area on a specific link.
+- Clean service checks do not clear silent OSPF faults on redundant topologies.
+- If hosts lose DHCP renewal behind one router, keep OSPF in play.
+- A clean `ospf_snapshot` does not clear L2 identity faults: duplicate MACs can create intermittent or `status=unknown` routed symptoms while FRR and routes still look healthy, so verify `l2_snapshot` has run before concluding no anomaly.

--- a/src/agent/community/sade/.claude/skills/resource-contention-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/resource-contention-skill/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: resource-contention-skill
+description: Identify per-host resource and load faults — sender or receiver resource contention, sender application delay, web DoS attack. Use when a host shows stress/flood-tool processes, CPU spikes, TCP socket spikes, or slow localhost responses while same-role peers stay clean.
+---
+
+# Resource Contention and DoS
+
+## What counts as direct evidence
+
+A `stress_tool` / `http_flood_tool` entry means a RUNNING process surfaced by `pressure_sweep`. Installed binaries without a running process do not count.
+
+One direct probe on the candidate to confirm ownership is enough — do not chain extra investigations once the family is confirmed.
+
+## Not host_crash
+
+`host_crash` means the container was killed/stopped/removed: no response at all, same-role peers clean. An isolated `exec_failed`/timeout on one web/app server while ICMP still answers is `sender_resource_contention`, not `host_crash`. Do not require seeing `stress-ng` in `ps` after the container is already too loaded to answer process probes.
+
+## Not load_balancer_overload
+
+Stay here only when the pressure signal is on a non-LB backend or client. If the flagged device is the load balancer, use `load-balancer-skill`.
+
+## sender_resource_contention vs sender_application_delay
+
+Both produce a slow backend. `sender_resource_contention` requires a resource signal (`stress_tool`, `cpu_hot_process`, `cpu_hot_service_daemon`, `tcp_estab_spike`, or an isolated exec timeout). `sender_application_delay` fires only when the backend is slow AND no resource signal is present. If any resource flag fires, it is NOT `sender_application_delay`.
+
+## stress_tool vs http_flood_tool
+
+`stress_tool` consumes local CPU/memory — the faulty device is the host running it. `http_flood_tool` drives abusive traffic at a victim — the faulty device is the victim, not the attacker.

--- a/src/agent/community/sade/.claude/skills/tc-fault-skill/SKILL.md
+++ b/src/agent/community/sade/.claude/skills/tc-fault-skill/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tc-fault-skill
+description: Identify generic traffic-control faults — link bandwidth throttling, link packet corruption, incast traffic limitation. Use when tc qdisc output shows tbf or netem shaping on a network-path interface.
+---
+
+# Traffic Control Faults
+
+## What These Faults Mean
+
+- `link_bandwidth_throttling`: a device interface owns a `tbf` shaping rule that caps throughput.
+- `link_high_packet_corruption`: a `netem corrupt` rule randomly damages packets, so TCP retransmits and throughput collapses.
+- `incast_traffic_network_limitation`: the qdisc stack combines `netem` and `tbf`, creating fan-in or queueing behavior that looks worse than a simple bandwidth cap.
+
+## Leading Signals
+
+- `tc qdisc show` reveals a non-default shaping stack on the implicated interface.
+- The qdisc layout itself is the decisive proof; RTT or throughput symptoms only tell you where to look.
+
+## When To Use
+
+- Quiet throughput degradation
+- Extreme jitter with little or no packet loss
+- Suspected qdisc or shaping on a server or router interface
+- If ownership is still unclear, run `tc_snapshot.py` from `diagnosis-methodology-skill/scripts` to find non-default qdisc stacks before targeted tc checks.
+
+## Exact Calls
+
+- `exec_shell(host_name="<host>", command="tc qdisc show dev <interface>")`
+- `get_tc_statistics(host_name="<host>", intf_name="<interface>")`
+- `exec_shell(host_name="<host>", command="tc -s qdisc show dev <interface>")`
+
+## Required Tool Usage
+
+- `get_tc_statistics` always needs both `host_name` and `intf_name`.
+- Check the specific interface under test, not a default placeholder. If the bottleneck may be on a different interface, use that one.
+
+## Guardrails
+
+- The decisive signal is the qdisc stack itself, not just high RTT.
+- Report only the device that actually owns the shaping rule.
+- Sending clients are victims, not faulty devices, unless a different skill proves otherwise.

--- a/src/agent/community/sade/README.md
+++ b/src/agent/community/sade/README.md
@@ -1,0 +1,73 @@
+# SADE — Symptom-Aware Diagnostic Escalation (community agent)
+
+SADE is a methodology-grounded Claude Code agent for the NIKA network-troubleshooting
+benchmark. It pairs a **phase-gated diagnostic workflow** (separating evidence
+acquisition from hypothesis commitment) with a **15-skill library** that maps symptoms
+to confirmation patterns, and plugs into NIKA's standard pluggable-agent interface
+(`agent.protocols.TroubleshootingAgent`).
+
+> Built on top of **[NIKA](https://github.com/sands-lab/nika)** — SADE uses NIKA's
+> unmodified orchestrator, fault-injection environment, and evaluation pipeline, and
+> adds only the agent under this directory.
+
+## Paper / citation
+
+This work is presented in the paper **"SADE: Symptom-Aware Diagnostic Escalation for
+LLM-Based Network Troubleshooting"** — https://arxiv.org/abs/2605.04530
+
+If you use SADE in academic research, please cite the paper:
+
+```bibtex
+@misc{sade2026,
+  title         = {SADE: Symptom-Aware Diagnostic Escalation for LLM-Based Network Troubleshooting},
+  year          = {2026},
+  eprint        = {2605.04530},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.NI},
+  url           = {https://arxiv.org/abs/2605.04530}
+}
+```
+
+## Install
+
+SADE drives Claude Code through the Anthropic Agent SDK, declared as an optional extra:
+
+```bash
+uv sync --extra sade          # or: pip install -e ".[sade]"
+```
+
+Set `ANTHROPIC_API_KEY` in the repo-root `.env` (or the environment) before running.
+
+## Run
+
+```bash
+nika agent run -a sade -m claude-sonnet-4-6 -n 20
+```
+
+Produces the same session artifacts as the other agents (`messages.jsonl`,
+`submission.json`) and submits through NIKA's task MCP server.
+
+## Layout
+
+```
+src/agent/community/sade/
+├── agent.py            # SadeAgent (TroubleshootingAgent contract)
+├── h.py                # helper-script launcher used by the skills (python h.py <script>)
+├── prompts/            # sade_prompt.py (phase-gated workflow)
+└── .claude/
+    ├── CLAUDE.md       # fault-routing + tool index
+    └── skills/         # 15 skills: 12 fault-family books, diagnosis-methodology
+                        # (with read-only helper scripts), and 2 utility books
+```
+
+## How it works
+
+- **Diagnosis** runs inside a single Claude Code session against NIKA's Kathara MCP
+  servers. The system prompt enforces five phases (blind start → branch → symptom-first
+  diagnosis → broad-search escalation → submission); the skill library and `CLAUDE.md`
+  index gate which fault family is entered, and only after a real symptom implicates it.
+- **Submission** calls the task MCP server's `submit` tool with the canonical
+  `root_cause_name` / `faulty_devices`.
+- The skills' read-only helper scripts (`infra_sweep`, `ospf_snapshot`, `bgp_snapshot`,
+  …) are invoked through `h.py`, which runs them with the project interpreter and injects
+  the active lab name from the running NIKA session.

--- a/src/agent/community/sade/agent.py
+++ b/src/agent/community/sade/agent.py
@@ -1,0 +1,279 @@
+"""SADE community agent — Symptom-Aware Diagnostic Escalation over Claude Code.
+
+Implements the ``agent.protocols.TroubleshootingAgent`` contract
+(``session_id`` + ``async def run(task_description) -> dict``) and is selected
+via ``nika agent run -a sade``.
+
+Unlike the LangGraph paths, SADE drives a single Claude Code session
+(``claude-agent-sdk``) with a phase-gated system prompt and a 15-skill library
+loaded from this package's ``.claude/`` directory. It still produces the same
+diagnosis -> submission outcome through NIKA's Kathara + task MCP servers, and
+writes structured events to the session's ``messages.jsonl`` in the schema the
+NIKA trace parser/evaluator expects.
+
+Reference: SADE (arXiv:2605.04530), built on NIKA.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+from dotenv import load_dotenv
+
+from agent.utils.loggers import AgentCallbackLogger
+from agent.utils.mcp_servers import MCPServerConfig
+from nika.utils.logger import system_logger
+from nika.utils.session import Session
+
+from .prompts.sade_prompt import SADE_PROMPT
+
+load_dotenv()
+
+# Directory holding this agent's `.claude/` skill library, `CLAUDE.md`, and the
+# `h.py` helper launcher. The Claude Code SDK uses it as the working directory
+# so skills and helpers resolve with simple relative paths (`python h.py ...`).
+PACKAGE_DIR = Path(__file__).resolve().parent
+
+# The NIKA trace parser derives token/step counts from the diagnosis agent
+# (``agent_filter="diagnosis_agent"``); SADE does diagnosis + submission in one
+# Claude Code session, so it tags its events with this name.
+AGENT_TAG = "diagnosis_agent"
+
+# Fraction of the turn budget at which a single workflow reminder is injected.
+TURN_REMINDER_FRAC = 0.50
+
+SADE_REMINDER = (
+    "SADE REMINDER: API turn {turn}/{total} ({remaining} remaining). "
+    "If direct evidence on the owning device already matches a fault-family "
+    "fingerprint, submit NOW — do not hypothesize secondary mechanisms the "
+    "topology does not support. If you have a symptom but no owner yet, stay "
+    "on that lead and stop broad probing. If you still have no symptom, do one "
+    "broad lower-to-higher-layer escalation sweep, then submit `is_anomaly=False` "
+    "only if that sweep finds nothing. Check the submit() signature in CLAUDE.md "
+    "before calling — wrong types end the session."
+)
+
+
+def _require_api_key() -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is not set. Add it to the repo-root .env or "
+            "export it before running `nika agent run -a sade`."
+        )
+    return api_key
+
+
+def _resolve_python() -> str:
+    """Interpreter used to spawn the stdio MCP servers.
+
+    NIKA's ``MCPServerConfig`` hardcodes ``python3`` (absent on native
+    Windows). The SDK spawns these servers on the host, so prefer the
+    interpreter currently running NIKA — it is guaranteed to exist and to
+    have the ``nika`` package importable.
+    """
+    return sys.executable or "python3"
+
+
+def _to_sdk_mcp_servers(config: dict[str, Any]) -> dict[str, Any]:
+    """Adapt NIKA's MultiServerMCPClient config to claude-agent-sdk stdio format.
+
+    NIKA returns ``{"transport": "stdio", "command": ..., "args": ...}`` (the
+    langchain-mcp-adapters shape); claude-agent-sdk expects
+    ``{"type": "stdio", "command": ..., "args": ..., "env": ...}``.
+    """
+    servers: dict[str, Any] = {}
+    for name, spec in config.items():
+        command = spec.get("command")
+        if command in ("python3", "python"):
+            command = _resolve_python()
+        servers[name] = {
+            "type": "stdio",
+            "command": command,
+            "args": list(spec.get("args", [])),
+            "env": dict(spec.get("env", {})),
+        }
+    return servers
+
+
+def _usage_metadata(usage: dict[str, Any] | None) -> dict[str, int]:
+    """Map an Anthropic per-turn usage dict to the langchain-style fields the
+    NIKA trace parser reads from ``llm_end`` (``usage_metadata.input_tokens`` /
+    ``output_tokens``). Input counts cached + uncached prompt tokens.
+    """
+    u = usage or {}
+    return {
+        "input_tokens": (
+            u.get("input_tokens", 0)
+            + u.get("cache_creation_input_tokens", 0)
+            + u.get("cache_read_input_tokens", 0)
+        ),
+        "output_tokens": u.get("output_tokens", 0),
+    }
+
+
+class SadeAgent:
+    """SADE: phase-gated Claude Code agent with the 15-skill library.
+
+    Implements ``agent.protocols.TroubleshootingAgent``. Diagnosis and
+    submission run inside a single Claude Code session: diagnosis tools come
+    from the Kathara MCP servers, submission via the task MCP server's
+    ``submit`` tool. Structured events are written to ``messages.jsonl``.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        llm_backend: str = "claude",
+        model: str = "claude-sonnet-4-6",
+        max_steps: int = 20,
+        **_: Any,
+    ) -> None:
+        self.session_id = session_id
+        self.llm_backend = llm_backend
+        self.model = model
+        self.max_steps = max_steps
+        self.session = Session()
+        self.session.load_running_session(session_id=session_id)
+
+        mcp = MCPServerConfig(session_id=session_id)
+        merged = {**mcp.load_config(if_submit=False), **mcp.load_config(if_submit=True)}
+        self.mcp_servers = _to_sdk_mcp_servers(merged)
+
+    async def run(self, task_description: str) -> dict[str, Any]:
+        api_key = _require_api_key()
+        logger = AgentCallbackLogger(agent=AGENT_TAG, session_dir=self.session.session_dir)
+        system_logger.info(f"sade: starting session {self.session_id}")
+
+        options = ClaudeAgentOptions(
+            system_prompt=SADE_PROMPT,
+            model=self.model,
+            cwd=str(PACKAGE_DIR),
+            mcp_servers=self.mcp_servers,
+            max_turns=self.max_steps,
+            permission_mode="bypassPermissions",
+            # Exposes this package's `.claude/` skill library + CLAUDE.md.
+            setting_sources=["project"],
+            env={
+                "ANTHROPIC_API_KEY": api_key,
+                "ANTHROPIC_AUTH_TOKEN": "",
+                # Lets `h.py` (spawned from the Bash tool, outside the MCP
+                # launch context) resolve the running lab for LAB_NAME.
+                "NIKA_SESSION_ID": self.session_id,
+            },
+        )
+
+        logger._log(
+            "llm_start",
+            {
+                "messages": {"role": "user", "content": task_description},
+                "model": {"name": self.model, "backend": self.llm_backend},
+                "mcp_servers": list(self.mcp_servers.keys()),
+            },
+        )
+
+        result_text = ""
+        api_turn_count = 0
+        reminded = False
+        has_submitted = False
+        reminder_at = int(self.max_steps * TURN_REMINDER_FRAC)
+        in_tokens = 0
+        out_tokens = 0
+        turn_text: list[str] = []
+
+        def _flush_turn() -> None:
+            """Emit the accumulated assistant turn as one canonical ``llm_end``.
+
+            NIKA's parser counts ``llm_end`` events as steps and the LLM judge
+            reads ``text`` as the agent's response, so each turn's reasoning is
+            emitted here. Token usage is reported once at the ResultMessage:
+            per-message SDK usage is a streamed partial that repeats across a
+            turn and would mis-sum.
+            """
+            nonlocal turn_text
+            if turn_text:
+                logger._log("llm_end", {"text": "\n".join(turn_text), "usage_metadata": {}})
+                turn_text = []
+
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(task_description)
+            async for message in client.receive_messages():
+                if isinstance(message, SystemMessage) and message.subtype == "init":
+                    system_logger.info(f"sade: session started - {message.data.get('session_id')}")
+                elif isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, ThinkingBlock):
+                            api_turn_count += 1
+                            turn_text.append(block.thinking)
+                        elif isinstance(block, TextBlock):
+                            turn_text.append(block.text)
+                        elif isinstance(block, ToolUseBlock):
+                            # Emit the reasoning that led to this call, then the
+                            # tool call (llm_end -> tool_start order, like NIKA).
+                            _flush_turn()
+                            logger._log(
+                                "tool_start",
+                                {"tool": {"name": block.name}, "input": str(block.input)},
+                            )
+                            if "submit" in block.name:
+                                has_submitted = True
+                elif isinstance(message, UserMessage):
+                    _flush_turn()  # close the turn that called these tools
+                    content = message.content if isinstance(message.content, list) else []
+                    for block in content:
+                        if isinstance(block, ToolResultBlock):
+                            if block.is_error:
+                                logger._log("tool_error", {"output": str(block.content)})
+                            else:
+                                logger._log(
+                                    "tool_end",
+                                    {"output": str(block.content), "output_type": "tool_result"},
+                                )
+                    if not reminded and not has_submitted and api_turn_count >= reminder_at:
+                        reminded = True
+                        remaining = self.max_steps - api_turn_count
+                        text = SADE_REMINDER.format(
+                            turn=api_turn_count, total=self.max_steps, remaining=remaining
+                        )
+                        await client.query(text)
+                        system_logger.info(
+                            f"sade: REMINDER at API turn {api_turn_count}/{self.max_steps}"
+                        )
+                elif isinstance(message, ResultMessage):
+                    _flush_turn()  # flush any trailing assistant text
+                    result_text = message.result or ""
+                    md = _usage_metadata(message.usage)
+                    in_tokens = md["input_tokens"]
+                    out_tokens = md["output_tokens"]
+                    # Final `llm_end`: the agent's result text + the authoritative
+                    # cumulative token usage (the parser sums usage_metadata).
+                    logger._log("llm_end", {"text": result_text, "usage_metadata": md})
+                    system_logger.info(
+                        f"sade: session complete - stop_reason={message.stop_reason}, "
+                        f"submitted={has_submitted}, api_turns={api_turn_count}, "
+                        f"sdk_turns={message.num_turns}, in_tokens={in_tokens}, out_tokens={out_tokens}"
+                    )
+                    break
+
+        return {
+            "result": result_text,
+            "has_submitted": has_submitted,
+            "api_turns": api_turn_count,
+            "in_tokens": in_tokens,
+            "out_tokens": out_tokens,
+        }

--- a/src/agent/community/sade/h.py
+++ b/src/agent/community/sade/h.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""Tiny launcher for diagnosis-methodology helper scripts.
+
+Usage from the agent's working directory (this package directory):
+    python h.py <script_name> [args...]
+
+`script_name` may include or omit the `.py` suffix. The launcher locates the
+script under `.claude/skills/diagnosis-methodology-skill/scripts/` (next to
+this file) and runs it with the project's `.venv` interpreter so the helper
+picks up its dependencies. This exists so the agent does not have to remember
+(or typo) the long path to each helper.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# This file lives at <repo>/src/agent/community/sade/h.py; the skill library is
+# a sibling `.claude/` directory and the project `.venv` is at the repo root.
+ROOT = Path(__file__).resolve().parent
+
+_VENV_REL = (
+    Path(".venv") / "Scripts" / "python.exe"
+    if sys.platform == "win32"
+    else Path(".venv") / "bin" / "python"
+)
+
+
+def _find_python() -> str:
+    """Interpreter with the `nika` package installed.
+
+    Walk up from this file until a project `.venv` is found (works for both the
+    standalone SADE layout and the embedded `src/agent/community/sade` layout),
+    then fall back to the interpreter that launched this script.
+    """
+    for base in (ROOT, *ROOT.parents):
+        candidate = base / _VENV_REL
+        if candidate.exists():
+            return str(candidate)
+    return sys.executable
+
+
+PYTHON = _find_python()
+
+SKILLS_DIR = ROOT / ".claude" / "skills"
+SCRIPTS = SKILLS_DIR / "diagnosis-methodology-skill" / "scripts"
+
+# Special-purpose scripts that live outside the diagnosis-methodology folder.
+EXTRA_SCRIPTS = {
+    "parse_large": SKILLS_DIR / "big-return-skill" / "scripts" / "parse_large_output.py",
+    "bgp_snapshot": SKILLS_DIR / "bgp-fault-skill" / "scripts" / "bgp_snapshot.py",
+}
+
+
+def _repo_root() -> Path:
+    """Outer NIKA repo root (src/agent/community/sade -> four levels up)."""
+    return ROOT.parents[3] if len(ROOT.parents) >= 4 else ROOT
+
+
+def _lab_name_from_session() -> str | None:
+    """Resolve the running lab name from the active NIKA session, if any.
+
+    The Bash tool spawns h.py outside the MCP launch context, so LAB_NAME does
+    not flow through. The agent exports NIKA_SESSION_ID; read the scenario from
+    that session's ``run.json`` under ``results/<id>/``. Falls back to the
+    legacy standalone ``runtime/current_session.json``.
+    """
+    candidates: list[Path] = []
+    session_id = os.environ.get("NIKA_SESSION_ID")
+    if session_id:
+        candidates.append(_repo_root() / "results" / session_id / "run.json")
+    candidates.append(_repo_root() / "runtime" / "current_session.json")
+    candidates.append(ROOT / "runtime" / "current_session.json")
+    for path in candidates:
+        try:
+            meta = json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        for key in ("scenario_name", "scenario", "lab_name"):
+            if meta.get(key):
+                return str(meta[key])
+    return None
+
+
+def _child_env() -> dict:
+    """Inherit parent env, injecting LAB_NAME from the running session if unset."""
+    env = os.environ.copy()
+    if env.get("LAB_NAME"):
+        return env
+    lab = _lab_name_from_session()
+    if lab:
+        env["LAB_NAME"] = lab
+    return env
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write(
+            "usage: python h.py <script_name> [args...]\n"
+            f"available scripts under {SCRIPTS}:\n"
+        )
+        if SCRIPTS.is_dir():
+            for name in sorted(p.name for p in SCRIPTS.glob("*.py")):
+                if not name.startswith("_"):
+                    sys.stderr.write(f"  {name[:-3]}\n")
+        sys.stderr.write("special:\n")
+        for name in EXTRA_SCRIPTS:
+            sys.stderr.write(f"  {name}\n")
+        return 2
+
+    env = _child_env()
+    name = sys.argv[1]
+
+    if name in EXTRA_SCRIPTS:
+        return subprocess.call([PYTHON, str(EXTRA_SCRIPTS[name])] + sys.argv[2:], env=env)
+
+    if not name.endswith(".py"):
+        name += ".py"
+    script_path = SCRIPTS / name
+    if not script_path.is_file():
+        sys.stderr.write(f"helper not found: {script_path}\n")
+        return 2
+
+    return subprocess.call([PYTHON, str(script_path)] + sys.argv[2:], env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/community/sade/prompts/__init__.py
+++ b/src/agent/community/sade/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt templates for Claude Code agents."""

--- a/src/agent/community/sade/prompts/sade_prompt.py
+++ b/src/agent/community/sade/prompts/sade_prompt.py
@@ -1,0 +1,58 @@
+"""Runtime prompt for the SADE agent."""
+
+from textwrap import dedent
+
+SADE_PROMPT = dedent("""
+You are a network diagnosis agent. Identify the root cause of observed network anomalies and call `submit()` with the result.
+
+## Tools
+Three complementary layers:
+- **MCP tools** (`mcp__...`): raw device access — reachability probes, shell execution, and submission. Appropriate for single-device confirmation.
+- **`Skill` tool**: enters a named fault-family or methodology skill. Each skill exposes its diagnostic fingerprints and names the helper that confirms or rules out the family. Enter the relevant skill before fanning out raw commands. Input parameter is `skill`, not `name` — invoke as `Skill(skill="<skill-name>")` (e.g. `Skill(skill="link-fault-skill")`). Passing `{name: ...}` will fail validation.
+- **`Bash` tool**: executes helper scripts through a single launcher. Your working directory already contains the launcher `h.py`; invoke every helper as exactly `python h.py <script> [args]`, and a bare `python h.py` lists the available scripts. Do **NOT** prepend `cd <path> &&`, do **NOT** convert to a WSL `/mnt/c/...` path, and do **NOT** rewrite as an absolute Windows path — the cwd is set correctly by the harness, and any of those rewrites will fail because the shell here is Git-Bash (drives appear as `/c/...`, not `/mnt/c/...`) and the absolute path may point at a stale tree. Do not reconstruct `.claude/skills/...` paths from memory. Use `--help` to discover flags; do not read helper source.
+
+`CLAUDE.md` is the routing, fault, and tool index. The phase gates defined below take precedence over any inclination to skip ahead.
+
+## SADE Workflow
+
+**Phase 1 — Blind start.** Call `list_avail_problems()` and `get_reachability()` in parallel. No other action.
+
+**Phase 2 — Branch.** If a real symptom is present → Phase 3. Otherwise → Phase 4 (do not probe services or individual devices yet).
+
+**Phase 3 — Symptom-first diagnosis.**
+1. State the active lead in one sentence: which symptom, which src→dst path.
+2. Use `CLAUDE.md` to map the symptom to a fault family. Enter that family via `Skill`; do not issue raw MCP calls beforehand.
+3. Run the helper named by the skill. Reason from its output rather than reimplementing the same check with raw `exec_shell`.
+4. Stay on the active lead until a single device, path, or service owner is implicated.
+5. Prefer differential tests: healthy peer versus suspect, hostname versus direct IP, VIP versus backend, one path versus another.
+6. When competing leads coexist, choose the cause that explains the larger set of symptoms. If anomaly A explains anomaly B (cascade direction A → B), A is the lead — not B.
+7. **Stop-and-submit.** Once direct evidence on the owning device matches a fault-family fingerprint, advance to Phase 5. Do not speculate about mechanisms the topology does not include.
+
+**Phase 4 — Broad-search escalation.** First action MUST be `Skill: diagnosis-methodology-skill`. Follow its ordered phases (L1/L2 → routing → host-local → service). Do not skip layers.
+- A helper surfaces an anomaly → return to Phase 3 with that anomaly as the active lead.
+- Every phase clean → Phase 5 with `is_anomaly=False`.
+
+**Phase 5 — Submission.** Before `submit()`, re-enter the matched family skill (when applicable) to confirm the canonical `root_cause_name` and `faulty_devices` list.
+- Only submit `root_cause_name` values returned by `list_avail_problems()`.
+- `is_anomaly=False` is valid only after Phase 1 plus a complete Phase 4 pass leave nothing implicated.
+- Do not restart devices — the task is diagnosis, not repair.
+- Argument types: `is_anomaly` bool, `root_cause_name` list[str], `faulty_devices` list[str] (always plural), `confidence` number. Unquoted. Validation errors typically terminate the session.
+
+## What qualifies as a real symptom
+**Yes:** `loss_percent > 0` in `get_reachability`; ping or curl timeout, connection refused, TCP RST, ICMP unreachable; DNS NXDOMAIN, SERVFAIL, or a wrong answer for a name the topology declares resolvable; HTTP non-2xx/3xx where traffic should succeed; any device or path explicitly flagged by a helper.
+
+**Needs confirmation before promoting (do NOT enter a fault-family skill yet):** a `get_reachability` row with `status="unknown"` and null tx/rx/loss. The harness resolves the destination name before pinging, so a name-resolution failure (DNS misconfig, missing record, wrong resolver, faulty/crashed name server, transient lookup error) produces this exact pattern even when the underlying L3 path is healthy. Re-test the same src→dst with a direct-IP probe — `exec_shell(src, "ping -c2 <dst-ip>")` using the IP from the same `get_reachability` payload — before treating it as a symptom. Outcomes:
+- Direct-IP ping succeeds with 0% loss → the unknown row is a name-resolution artifact, not a path fault. Treat the failure as a service-layer symptom (resolver/DNS/host-ip identity) and route accordingly; do NOT enter routing/link/L1-L2 skills on this signal alone.
+- Direct-IP ping shows real loss/timeout/unreachable → promote to a real symptom and continue Phase 3 with the matching family.
+This rule is topology-agnostic: any `status="unknown"` row in any lab must be confirmed by a direct-IP probe before driving family selection.
+
+**No (on their own):** latency or throughput without comparison against `baseline-behavior-skill` or a healthy peer; `systemctl inactive` while `ss`/`ps` confirm the service is listening and responding; a service running under an unexpected binary that still answers; configuration that "looks wrong" but breaks no observed traffic; any single observation unconfirmed by a differential or baseline check.
+
+## Hard gates
+- Consult `baseline-behavior-skill` before promoting any observation to a symptom.
+- Do not enter a fault-family skill until that family is implicated by a real symptom. "Interesting config" is not implication.
+- **Helper precedence.** When a helper produces the same evidence as a raw `exec_shell` fan-out, use the helper. Raw `exec_shell` is for single-device confirmation, not broad discovery. Never read helper source to learn flags — use `--help`.
+- In Phase 4, do not issue service-layer probes (DNS, HTTP, curl, nginx configuration) before the L1/L2 snapshots.
+- Reason from the symptom, not from the most conspicuous configuration artifact.
+- If live traffic contradicts a theory, resolve the contradiction before naming the faulty device.
+""").strip()

--- a/src/agent/registry.py
+++ b/src/agent/registry.py
@@ -45,5 +45,16 @@ def create_agent(
                 reasoning_effort=reasoning_effort,
                 stream_output=stream_output,
             )
+        case "sade":
+            # Lazy import: claude-agent-sdk is an optional dependency only
+            # required for the community SADE agent.
+            from agent.community.sade.agent import SadeAgent
+
+            return SadeAgent(
+                session_id=session_id,
+                llm_backend=llm_backend,
+                model=model,
+                max_steps=max_steps,
+            )
         case _:
             raise ValueError(f"Unsupported agent type: {agent_type!r}")

--- a/src/nika/codex_cli/commands/agent.py
+++ b/src/nika/codex_cli/commands/agent.py
@@ -4,7 +4,7 @@ import typer
 
 from agent.cli.codex_worker import REASONING_EFFORT_LEVELS
 
-SUPPORTED_AGENT_TYPES = ("react", "mock", "cli")
+SUPPORTED_AGENT_TYPES = ("react", "mock", "cli", "sade")
 SUPPORTED_LLM_BACKENDS = ("openai", "ollama", "deepseek")
 
 agent_app = typer.Typer(help="Troubleshooting agents.")


### PR DESCRIPTION
Move the SADE contribution into NIKA's pluggable agent architecture and address the maintainer review feedback:

- implement SadeAgent against agent.protocols.TroubleshootingAgent; register `sade` in agent.registry and in the `nika agent list` type set
- add the 15-skill library, phase-gated prompt, CLAUDE.md, and the h.py helper launcher under src/agent/community/sade
- declare claude-agent-sdk as the optional `sade` extra
- document the agent and the paper citation (arXiv:2605.04530)
- drop the duplicated network_agents/ tree and all experiment artifacts

NIKA core is otherwise unchanged. Thank you!