### PR TITLE
add result_dir option to nika eval and handle package versions compatibility in the pyproject.toml

### DIFF
--- a/benchmark/benchmark_dev.yaml
+++ b/benchmark/benchmark_dev.yaml
@@ -1,0 +1,11 @@
+cases:
+- scenario: dc_clos_bgp
+  topo_size: s
+  problem: bgp_asn_misconfig
+  inject:
+    host_name: leaf_router_0_0
+- scenario: ospf_enterprise_dhcp
+  topo_size: s
+  problem: arp_acl_block
+  inject:
+    host_name: pc_1_1_1_1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "pydantic",
+    "pydantic>=2.11,<2.14",
     "openai",
     "instructor",
     "kathara",
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv",
     "langchain-deepseek",
     "langgraph",
-    "mcp[cli]",
+    "mcp[cli]==1.28.0",
     "langchain-mcp-adapters",
     "langchain-ollama",
     "langchain",

--- a/src/nika/cli/commands/evaluation.py
+++ b/src/nika/cli/commands/evaluation.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from nika.config import ENV_RESULT_DIR
 from nika.utils.agent_config import ENV_JUDGE_MODEL, ENV_JUDGE_PROVIDER
 
 eval_app = typer.Typer(help="Evaluate a completed agent session.")
@@ -93,6 +94,12 @@ def eval_summary(
         "--model",
         help="Include only sessions run with this model id (repeatable).",
     ),
+    result_dir: str | None = typer.Option(
+        None,
+        "--result_dir",
+        envvar=ENV_RESULT_DIR,
+        help="Results parent directory (default: results/). Session output goes to {result_dir}/{session_id}.",
+    ),
 ) -> None:
     """Aggregate finished sessions under results/ into one CSV file."""
     from nika.workflows.eval.summary import run_eval_summary
@@ -106,6 +113,7 @@ def eval_summary(
             session_ids=session_id,
             agent_types=agent,
             models=model,
+            results_dir=result_dir
         )
     except (FileNotFoundError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/src/nika/evaluator/result_log.py
+++ b/src/nika/evaluator/result_log.py
@@ -67,8 +67,10 @@ def _session_duration_seconds(start_time, end_time) -> float | None:
         return round((end_dt - start_dt).total_seconds(), 2)
 
 
-def default_summary_csv_path() -> str:
-    return os.path.join(RESULTS_DIR, "0_summary", "evaluation_summary.csv")
+def default_summary_csv_path(result_dir=None) -> str:
+    if result_dir is None:
+        result_dir = RESULTS_DIR
+    return os.path.join(result_dir, "0_summary", "evaluation_summary.csv")
 
 
 def missing_summary_artifacts(session_dir: Path) -> list[str]:

--- a/src/nika/workflows/eval/summary.py
+++ b/src/nika/workflows/eval/summary.py
@@ -94,5 +94,5 @@ def run_eval_summary(
         selected.append(session_dir)
 
     eval_results = [build_eval_result_from_session_dir(session_dir) for session_dir in selected]
-    out_path = write_eval_summary_csv(eval_results, output_path or default_summary_csv_path())
+    out_path = write_eval_summary_csv(eval_results, output_path or default_summary_csv_path(results_dir))
     return out_path


### PR DESCRIPTION
Add a feature to allow running ` nika eval summary --result_dir results/test/` and the output will be saved under this result_dir folder.

Fix a stable pydantic version to avoid the error "[NOTE] Unable to evaluate type annotation 'dict[str, Any] | None'."
Also fix a stable mcp version to avoid "ImportError: cannot import name 'RequestContext' from 'mcp.shared.context' error.

