### PR TITLE
Fix two test errors in the refactored test suite

### DIFF
--- a/tests/agent/test_sandbox_unit.py
+++ b/tests/agent/test_sandbox_unit.py
@@ -117,7 +117,7 @@ class GatewayPhaseRouteTest:
     def _setup(self) -> None:
         clear_sessions()
         yield
-        self.tmp.cleanup()
+        clear_sessions()
 
     def test_advance_phase_via_http(self) -> None:
         register_session("sess-1", scenario_name="simple_bgp")

--- a/tests/nika/net_env/test_kathara_ospf_enterprise_verify.py
+++ b/tests/nika/net_env/test_kathara_ospf_enterprise_verify.py
@@ -46,7 +46,6 @@ class _OSPFEnterpriseVerifyBase(SharedSessionTestCase):
     def _setup_class(cls) -> None:
         if cls is _OSPFEnterpriseVerifyBase:
             pytest.skip("base test class")
-        super().setUpClass()
 
     def _runtime(self):
         from nika.runtime.factory import runtime_for_session


### PR DESCRIPTION
Two small bugs we met in the recent test refactor (0d51995) made some tests fail every time:

1. **`tests/agent/test_sandbox_unit.py` ; `GatewayPhaseRouteTest`**:  the cleanup   step that runs after each test calls `self.tmp.cleanup()`, but `self.tmp` is    never created anywhere in the class. So both tests in the class end with:

   ```
   AttributeError: 'GatewayPhaseRouteTest' object has no attribute 'tmp'
   ```
   What the setup/cleanup around these tests actually manages is the gateway  session registry, so the cleanup now calls `clear_sessions()` instead. This also makes sure a session registered by one test doesn't stay during later tests.

2. **`tests/nika/net_env/test_kathara_ospf_enterprise_verify.py`**: the  class-level setup calls `super().setUpClass()`. That is a leftover from when  the base class was a unittest class. `SharedSessionTestCase` is now a plain    pytest mixin (`tests/support/integration_base.py`) that has no `setUpClass`    method; its `_shared_session` already does the setup. So the call    raises `AttributeError` and all 6 tests in the file error before they even start, regardless of whether Docker/Kathara are available. Removing the call    fixes it.

After the fix, `uv run pytest tests/agent/test_sandbox_unit.py` passes, and the OSPF enterprise verify tests behave normally again