### PR TITLE
Fix sdn_clos at m/l topology sizes: size-aware verification and loop-free flooding

### DIFF
--- a/src/nika/net_env/kathara/sdn/clos_topo.py
+++ b/src/nika/net_env/kathara/sdn/clos_topo.py
@@ -218,11 +218,16 @@ class SDNClos(NetworkEnvBase):
         self.lab.connect_machine_to_link(controller.name, "switch_controller")
 
         # ---------- Controller start script ----------
+        # m/l fabrics have multiple spines, so the leaf-spine mesh contains
+        # loops; plain l2_learning floods on all ports and storms. Discovery +
+        # spanning_tree marks redundant inter-switch ports NO_FLOOD so floods
+        # follow a loop-free tree (--hold-down: no flooding until it settles).
         self.lab.create_file_from_list(
             [
                 "ip addr add 20.0.0.100/24 dev eth0",
                 "ip link set eth0 up",
-                "python3 /pox/pox.py forwarding.l2_learning &",
+                "python3 /pox/pox.py openflow.discovery openflow.spanning_tree"
+                " --no-flood --hold-down forwarding.l2_learning &",
             ],
             f"{controller.name}.startup",
         )
@@ -243,7 +248,13 @@ class SDNClos(NetworkEnvBase):
 
         self.load_machines()
 
+        self._host_ips = {h.name: h.ip_address for h in tot_host_list}
+
     def verify_lab(self) -> dict:
         from nika.net_env.kathara.sdn.verify import verify_sdn_clos_lab
 
-        return verify_sdn_clos_lab(self._build_runtime(), scenario_name=self.LAB_NAME)
+        return verify_sdn_clos_lab(
+            self._build_runtime(),
+            scenario_name=self.LAB_NAME,
+            host_ips=self._host_ips,
+        )

--- a/src/nika/net_env/kathara/sdn/verify.py
+++ b/src/nika/net_env/kathara/sdn/verify.py
@@ -42,16 +42,24 @@ def verify_sdn_star_lab(runtime: LabRuntime, *, scenario_name: str) -> dict[str,
     )
 
 
-def verify_sdn_clos_lab(runtime: LabRuntime, *, scenario_name: str) -> dict[str, Any]:
+def verify_sdn_clos_lab(
+    runtime: LabRuntime,
+    *,
+    scenario_name: str,
+    host_ips: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    # Host addresses are assigned sequentially across leaves, so pc_2_1's IP
+    # depends on hosts-per-leaf: 10.0.0.3 on "s" but 10.0.0.5/.9 on "m"/"l".
+    ips = host_ips or {"pc_1_1": "10.0.0.1", "pc_2_1": "10.0.0.3"}
     expected = ("controller", "spine_1", "leaf_1", "leaf_2", "pc_1_1", "pc_2_1")
     checks = {
         "nodes_deployed": nodes_deployed(runtime, expected),
         "controller_link_up": link_up(runtime, "controller"),
         "controller_process": process_running(runtime, "controller", "python3"),
         "ovs_switches_ready": _ovs_ready(runtime, ("spine_1", "leaf_1", "leaf_2")),
-        "pc_1_1_ipv4": host_has_ipv4(runtime, "pc_1_1", "10.0.0.1"),
-        "pc_2_1_ipv4": host_has_ipv4(runtime, "pc_2_1", "10.0.0.3"),
-        "cross_leaf_host_reachable": ping_ok(runtime, "pc_1_1", "10.0.0.3"),
+        "pc_1_1_ipv4": host_has_ipv4(runtime, "pc_1_1", ips["pc_1_1"]),
+        "pc_2_1_ipv4": host_has_ipv4(runtime, "pc_2_1", ips["pc_2_1"]),
+        "cross_leaf_host_reachable": ping_ok(runtime, "pc_1_1", ips["pc_2_1"]),
     }
     return build_lab_verify_result(
         scenario_name=scenario_name,


### PR DESCRIPTION
The `sdn_clos` scenario only worked for us at size `s`. At `m` and `l` it fails for what looks two independent reasons:

**1. The verifier checks IP addresses that are only correct at size `s`.** Host IPs are assigned one after another from a single pool across all leaves. At size `s` this puts `10.0.0.3` on `pc_2_1`, and the verifier hardcodes that. But at `m` and `l`, `pc_2_1` seems to get `10.0.0.5` and `10.0.0.9`, so the address check fails. On top of that, the "cross-leaf" ping at those sizes ends up pinging a host on the same leaf, so it doesn't actually test cross-leaf connectivity. `verify.py` now computes the expected addresses with the same assignment logic the lab uses, so the checks are correct at every size.

**2. At m and l, traffic between hosts on different leaves never gets through.** This only happens at m and l because of the number of spines: at size `s` there is a single spine, so the topology is a tree (exactly one path between any two switches, no loops). At `m` (2 spines) and `l` (4 spines), every leaf connects to every spine, so there are several paths between any two
leaves, and at layer 2 that means the links form loops.

The problem is that the POX controller was started with only the `l2_learning` app. When a switch does not yet know where a destination is, `l2_learning` floods the packet out of every port. In a topology with loops, a flooded packet comes back to a switch that already forwarded it and gets flooded again... The copies multiply until the links are saturated creating a broadcast storm. ARP never resolves, and cross-leaf pings just time out.

The fix is to enable POX's standard protection for looped topologies: the controller now also runs `openflow.discovery` (detects the links between switches) and `openflow.spanning_tree --no-flood --hold-down`. Flooded packets then follow the tree and reach every host exactly once, while `l2_learning` keeps installing the normal forwarding entries. Size `s` is unaffected since its topology is loop free by construction. This seemed to fix it for m and l.

```
uv run nika env run sdn_clos -s m   # verify_lab now passes
```

We have a few more fixes from our benchmark runs on this codebase; more PRs
will follow if these first ones are useful to you.