### PR TITLE
Reliability: timeouts and cleanup (issues with long benchmark runs)

### DIFF
--- a/src/agent/byo/langgraph/phases/diagnosis.py
+++ b/src/agent/byo/langgraph/phases/diagnosis.py
@@ -6,6 +6,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from agent.utils.template import OVERALL_DIAGNOSIS_PROMPT
 from agent.llm.model_factory import load_model
 from agent.utils.mcp_client import load_session_mcp_config
+from agent.utils.mcp_servers import harden_mcp_tools
 from agent.utils.phases import DIAGNOSIS
 
 load_dotenv()
@@ -31,6 +32,7 @@ class DiagnosisPhase:
 
     async def load_tools(self):
         self.tools: list[StructuredTool] = await self.client.get_tools()
+        harden_mcp_tools(self.tools)
         for tool in self.tools:
             tool.handle_tool_error = True
             tool.handle_validation_error = True

--- a/src/agent/byo/langgraph/phases/submission.py
+++ b/src/agent/byo/langgraph/phases/submission.py
@@ -6,6 +6,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from agent.utils.template import SUBMIT_PROMPT_TEMPLATE
 from agent.llm.model_factory import load_model
 from agent.utils.mcp_client import load_session_mcp_config
+from agent.utils.mcp_servers import harden_mcp_tools
 from agent.utils.phases import SUBMISSION
 from nika.utils.session import Session
 
@@ -35,6 +36,7 @@ class SubmissionPhase:
 
     async def load_tools(self):
         self.tools: list[StructuredTool] = await self.client.get_tools()
+        harden_mcp_tools(self.tools)
         for tool in self.tools:
             tool.handle_tool_error = True
             tool.handle_validation_error = True

--- a/src/agent/byo/langgraph/react_agent.py
+++ b/src/agent/byo/langgraph/react_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
@@ -176,22 +177,52 @@ class BasicReActAgent:
         submission_runner = submission_phase.get_agent()
 
         diag_text = state["diagnosis_report"][-1]
-        result = await submission_runner.ainvoke(
-            {
+        try:
+            result = await submission_runner.ainvoke(
+                {
+                    "messages": [
+                        HumanMessage(
+                            content=f"Based on the diagnosis report: {diag_text}, please provide the submission. Do not submit if no report available."
+                        ),
+                    ]
+                },
+                config={
+                    "callbacks": [
+                        AgentCallbackLogger(
+                            agent=SUBMISSION, session_dir=self.session_dir
+                        )
+                    ],
+                    "recursion_limit": self.max_steps,
+                },
+                debug=True,
+            )
+            return {
+                "messages": result["messages"],
+            }
+        except GraphRecursionError:
+            # The submit tool records submission.json the moment it is called,
+            # so the submission may already be on disk; raising here would fail
+            # the whole case and discard it. Either way the evaluator handles
+            # the session better than a crash does (missing submission scores
+            # as "no submission").
+            submitted = (Path(self.session_dir) / "submission.json").exists()
+            MessageLogger(agent=SUBMISSION, session_dir=self.session_dir).log(
+                "error",
+                {
+                    "message": (
+                        "Submission phase reached max recursion limit "
+                        + (
+                            "after a successful submission."
+                            if submitted
+                            else "without submitting."
+                        )
+                    )
+                },
+            )
+            return {
                 "messages": [
                     HumanMessage(
-                        content=f"Based on the diagnosis report: {diag_text}, please provide the submission. Do not submit if no report available."
-                    ),
-                ]
-            },
-            config={
-                "callbacks": [
-                    AgentCallbackLogger(agent=SUBMISSION, session_dir=self.session_dir)
+                        content="Error: submission phase did not finish within max steps."
+                    )
                 ],
-                "recursion_limit": self.max_steps,
-            },
-            debug=True,
-        )
-        return {
-            "messages": result["messages"],
-        }
+            }

--- a/src/agent/llm/model_factory.py
+++ b/src/agent/llm/model_factory.py
@@ -8,6 +8,11 @@ from langchain_openai import ChatOpenAI
 
 load_dotenv()
 
+# A request with no client-side timeout can block an agent step forever on a
+# half-dead connection. Override per deployment via env.
+LLM_TIMEOUT_SECONDS = float(os.getenv("NIKA_LLM_TIMEOUT", "300"))
+LLM_MAX_RETRIES = int(os.getenv("NIKA_LLM_RETRIES", "2"))
+
 
 def load_model(
     llm_provider: str = "openai", model: str = "gpt-5-mini"
@@ -23,12 +28,16 @@ def load_model(
     if llm_provider == "openai":
         return ChatOpenAI(
             model_name=model,
+            timeout=LLM_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
         )
 
     if llm_provider == "deepseek":
         return ChatDeepSeek(
             model=model,
             base_url="https://api.deepseek.com",
+            timeout=LLM_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
         )
 
     if llm_provider == "custom":
@@ -37,6 +46,8 @@ def load_model(
             base_url=os.getenv("CUSTOM_API_BASE"),
             api_key=os.getenv("CUSTOM_API_KEY", "dummy"),
             temperature=0,
+            timeout=LLM_TIMEOUT_SECONDS,
+            max_retries=LLM_MAX_RETRIES,
         )
 
     raise ValueError(f"Unsupported llm provider: {llm_provider}")

--- a/src/agent/utils/mcp_servers.py
+++ b/src/agent/utils/mcp_servers.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import functools
 import os
+from datetime import timedelta
+
+from langchain_core.tools import ToolException
 
 from nika.service.mcp_gateway.lifecycle import ENV_GATEWAY_AGENT_URL, ENV_GATEWAY_URL
 from nika.service.mcp_server.registry import (
@@ -13,6 +17,7 @@ from nika.service.mcp_server.registry import (
 
 __all__ = [
     "MCPServerConfig",
+    "harden_mcp_tools",
     "select_diagnosis_servers",
     "select_session_servers",
     "session_http_headers",
@@ -53,6 +58,94 @@ def select_session_servers(
     return servers
 
 
+# Read timeout for MCP client requests (seconds; 0 disables).
+# Without it the mcp ClientSession waits FOREVER on a lost response — the
+# observed failure mode: a benchmark run frozen for days with the server's
+# "Processing request of type ListToolsRequest" as the last log line.
+MCP_READ_TIMEOUT_ENV = "NIKA_MCP_READ_TIMEOUT"
+DEFAULT_MCP_READ_TIMEOUT_SECONDS = 120.0
+
+
+@functools.lru_cache(maxsize=1)
+def _mcp_read_timeout() -> timedelta | None:
+    raw = os.getenv(MCP_READ_TIMEOUT_ENV, "").strip()
+    try:
+        seconds = float(raw) if raw else DEFAULT_MCP_READ_TIMEOUT_SECONDS
+    except ValueError:
+        seconds = DEFAULT_MCP_READ_TIMEOUT_SECONDS
+    if seconds <= 0:
+        return None
+    if not _adapter_supports_session_kwargs():
+        print(
+            "WARNING: installed langchain_mcp_adapters does not support "
+            "session_kwargs — MCP calls have NO read timeout (hang risk); "
+            "upgrade with `pip install -U langchain-mcp-adapters`."
+        )
+        return None
+    return timedelta(seconds=seconds)
+
+
+def _adapter_supports_session_kwargs() -> bool:
+    """Feature-detect session_kwargs so an older adapter lib does not choke
+    on an unknown connection key."""
+    for module_name in (
+        "langchain_mcp_adapters.sessions",
+        "langchain_mcp_adapters.client",
+    ):
+        try:
+            module = __import__(
+                module_name, fromlist=["StreamableHttpConnection", "StdioConnection"]
+            )
+        except ImportError:
+            continue
+        for class_name in ("StreamableHttpConnection", "StdioConnection"):
+            connection = getattr(module, class_name, None)
+            if connection is not None:
+                return "session_kwargs" in getattr(connection, "__annotations__", {})
+    return False
+
+
+def _flatten_exception(exc: BaseException) -> str:
+    """Readable one-line summary of *exc*, unwrapping ExceptionGroups."""
+    if isinstance(exc, BaseExceptionGroup):
+        parts = [_flatten_exception(sub) for sub in exc.exceptions]
+        return "; ".join(dict.fromkeys(parts))
+    text = str(exc).strip()
+    return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+
+def _hardened_coroutine(tool_name: str, coro_fn):
+    @functools.wraps(coro_fn)
+    async def wrapped(*args, **kwargs):
+        try:
+            return await coro_fn(*args, **kwargs)
+        except ToolException:
+            raise
+        except Exception as exc:  # noqa: BLE001 - includes ExceptionGroup
+            raise ToolException(
+                f"MCP tool '{tool_name}' failed with a transport error "
+                f"({_flatten_exception(exc)}). Any result was lost; retry the "
+                "call if you still need it."
+            ) from exc
+
+    return wrapped
+
+
+def harden_mcp_tools(tools) -> None:
+    """Convert transport-level failures of MCP tools into ToolExceptions.
+
+    langchain opens a fresh MCP session per tool call, and the client's
+    stream reader can hit a teardown race (e.g. BrokenResourceError inside an
+    ExceptionGroup) when the server flushes output while the session closes.
+    ``handle_tool_error = True`` only catches ToolException, so without this
+    wrapper one such race escapes the tool node and kills the whole benchmark
+    case. With it, the agent sees an error ToolMessage and can just retry.
+    """
+    for tool in tools:
+        if getattr(tool, "coroutine", None) is not None:
+            tool.coroutine = _hardened_coroutine(tool.name, tool.coroutine)
+
+
 class MCPServerConfig:
     def __init__(self, session_id: str):
         if not session_id:
@@ -63,11 +156,17 @@ class MCPServerConfig:
         if name not in MCP_SERVER_SPECS:
             raise KeyError(f"Unknown MCP server: {name!r}")
         base = _gateway_base_url()
-        return {
+        entry = {
             "transport": "http",
             "url": f"{base}/mcp/{name}/mcp",
             "headers": session_http_headers(self.session_id),
         }
+        read_timeout = _mcp_read_timeout()
+        if read_timeout is not None:
+            # Forwarded to mcp.ClientSession(read_timeout_seconds=...):
+            # a lost/blocked response raises McpError instead of hanging.
+            entry["session_kwargs"] = {"read_timeout_seconds": read_timeout}
+        return entry
 
     def load_http_config(self, server_names: list[str]) -> dict:
         """Return HTTP MCP client config for *server_names*."""

--- a/src/nika/service/kathara/base_api.py
+++ b/src/nika/service/kathara/base_api.py
@@ -67,6 +67,11 @@ class KatharaBaseAPI:
         self._resolved_shell_cache[host_name] = shell
         return shell
 
+    # Sentinel returned to AGENT-FACING callers on exec timeout (the agent can
+    # reason about it). Internal orchestration code must never treat it as
+    # data — use exec_cmd_checked instead.
+    TIMEOUT_SENTINEL = "[TIMEOUT]"
+
     def exec_cmd(self, host_name: str, command: str, timeout: float = 10) -> str:
         """
         Run a command on a machine and return its output as a string.
@@ -77,7 +82,35 @@ class KatharaBaseAPI:
         try:
             return func_timeout(cmd_timeout, self._run_cmd, args=(host_name, cmd))
         except FunctionTimedOut:
-            return f"[TIMEOUT] Command '{command}' on '{host_name}' exceeded {cmd_timeout}s."
+            return f"{self.TIMEOUT_SENTINEL} Command '{command}' on '{host_name}' exceeded {cmd_timeout}s."
+
+    def exec_cmd_checked(
+        self,
+        host_name: str,
+        command: str,
+        timeout: float = 10,
+        retries: int = 2,
+        retry_delay: float = 5.0,
+    ) -> str:
+        """exec_cmd for ORCHESTRATION callers: retries transient timeouts and
+        raises instead of returning the ``[TIMEOUT]`` sentinel as data.
+
+        Right after a (re)deploy a container can be slow for a few seconds;
+        without this, the sentinel string leaks into JSON parsers and
+        verification comparisons and produces misleading downstream errors.
+        """
+        last_output = ""
+        for attempt in range(retries + 1):
+            output = self.exec_cmd(host_name, command, timeout=timeout)
+            if not output.startswith(self.TIMEOUT_SENTINEL):
+                return output
+            last_output = output
+            if attempt < retries:
+                time.sleep(retry_delay)
+        raise RuntimeError(
+            f"Command on '{host_name}' kept timing out after {retries + 1} "
+            f"attempts ({timeout}s each): {last_output}"
+        )
 
     def get_hosts(self) -> list[Machine]:
         """
@@ -190,7 +223,9 @@ class KatharaBaseAPI:
         """
 
         cmd = "ip -j addr"
-        result = self.exec_cmd(host_name, cmd)
+        # checked: a slow container right after deploy must retry, not hand a
+        # "[TIMEOUT] ..." string to json.loads below.
+        result = self.exec_cmd_checked(host_name, cmd)
 
         if isinstance(result, list):
             output = "\n".join(result)
@@ -200,7 +235,10 @@ class KatharaBaseAPI:
         try:
             ifaces = json.loads(output)
         except json.JSONDecodeError as e:
-            raise RuntimeError(f"Failed to parse `ip -j addr` output: {e}") from e
+            raise RuntimeError(
+                f"Failed to parse `ip -j addr` output from '{host_name}': {e}; "
+                f"raw output started with: {output[:200]!r}"
+            ) from e
 
         def format_ip(ip: str, prefix: Optional[int]) -> str:
             if with_prefix and prefix is not None:

--- a/src/nika/workflows/benchmark/run.py
+++ b/src/nika/workflows/benchmark/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -12,6 +13,7 @@ from pydantic import ValidationError
 
 from nika.config import BENCHMARK_DIR
 from nika.utils.session import Session
+from nika.utils.session_artifacts import RUN_FILENAME
 from nika.utils.session_store import SessionStore
 from nika.net_env.net_env_pool import scenario_requires_topo_size
 from nika.problems.prob_pool import get_problem_instance
@@ -25,6 +27,7 @@ from nika.workflows.benchmark.resume import (
 from nika.workflows.env.start import start_net_env
 from nika.workflows.eval.session import eval_results
 from nika.workflows.failure.inject import inject_failure
+from nika.workflows.session.close import close_session
 
 _BENCHMARK_DONE_PREFIX = "benchmark_done "
 _BENCHMARK_DONE_RE = re.compile(
@@ -239,36 +242,58 @@ def run_single_case(
     )
     session_dir = Path(SessionStore().get_session(session_id)["session_dir"])
 
-    inject_failure(
-        problem_names=[problem], session_id=session_id, param_overrides=params
-    )
+    try:
+        inject_failure(
+            problem_names=[problem], session_id=session_id, param_overrides=params
+        )
 
-    row = benchmark_row_from_case(
-        scenario=scenario,
-        problem=problem,
-        topo_size=topo_size,
-        inject_params=params,
-    )
-    Session().load_running_session(session_id=session_id).update_session(
-        "benchmark_fingerprint",
-        benchmark_row_fingerprint(row),
-    )
+        row = benchmark_row_from_case(
+            scenario=scenario,
+            problem=problem,
+            topo_size=topo_size,
+            inject_params=params,
+        )
+        Session().load_running_session(session_id=session_id).update_session(
+            "benchmark_fingerprint",
+            benchmark_row_fingerprint(row),
+        )
 
-    start_agent(
-        agent_type=agent_type,
-        llm_provider=llm_provider,
-        model=model,
-        max_steps=max_steps,
-        session_id=session_id,
-        stream_output=False,
-    )
+        start_agent(
+            agent_type=agent_type,
+            llm_provider=llm_provider,
+            model=model,
+            max_steps=max_steps,
+            session_id=session_id,
+            stream_output=False,
+        )
 
-    eval_results(
-        session_id=session_id,
-        run_judge=run_judge,
-        judge_llm_provider=judge_llm_provider,
-        judge_model=judge_model,
-    )
+        eval_results(
+            session_id=session_id,
+            run_judge=run_judge,
+            judge_llm_provider=judge_llm_provider,
+            judge_model=judge_model,
+        )
+    except BaseException:
+        # A failed case must not strand a "running" session with its Kathara
+        # lab still deployed (leaked labs burn CPU and skew later cases).
+        # eval_results closes the session on the success path.
+        try:
+            close_session(session_id=session_id, undeploy=True)
+            print(f"cleaned up failed session {session_id} (lab undeployed)")
+        except Exception as cleanup_error:  # noqa: BLE001 - best effort
+            print(f"WARNING: could not clean up session {session_id}: {cleanup_error}")
+        # If the failure happened after close_session already marked the run
+        # "finished" (e.g. during evaluation), resume would skip this case
+        # forever even though its artifacts are incomplete.
+        try:
+            run_path = session_dir / RUN_FILENAME
+            run_meta = json.loads(run_path.read_text(encoding="utf-8"))
+            if run_meta.get("status") == "finished":
+                run_meta["status"] = "error"
+                run_path.write_text(json.dumps(run_meta, indent=2), encoding="utf-8")
+        except Exception:  # noqa: BLE001 - best effort
+            pass
+        raise
 
     print(
         f"{_BENCHMARK_DONE_PREFIX}session_id={session_id} scenario={scenario} "

--- a/src/nika/workflows/eval/session.py
+++ b/src/nika/workflows/eval/session.py
@@ -232,4 +232,16 @@ def eval_results(
     close_session(session_id=resolved_session_id, undeploy=destroy_env)
     run_eval_metrics(session_id=resolved_session_id)
     if run_judge:
-        run_llm_judge(judge_llm_provider, judge_model, session_id=resolved_session_id)
+        try:
+            run_llm_judge(
+                judge_llm_provider, judge_model, session_id=resolved_session_id
+            )
+        except Exception as exc:  # noqa: BLE001 - judge is post-hoc analysis
+            # The session is closed and metrics are on disk; a transient judge
+            # failure (LLM/network) must not fail the whole case. The judge can
+            # be re-run offline on the closed session.
+            print(
+                f"WARNING: LLM judge failed for session {resolved_session_id}: {exc}\n"
+                f"Re-run it later with: nika eval judge -p {judge_llm_provider} "
+                f"-m {judge_model} --session_id {resolved_session_id}"
+            )

--- a/src/nika/workflows/failure/inject.py
+++ b/src/nika/workflows/failure/inject.py
@@ -1,5 +1,7 @@
 """Inject configured faults for the current session and write ground truth."""
 
+import json
+import os
 import time
 from datetime import datetime
 from enum import Enum
@@ -13,8 +15,8 @@ from nika.utils.logger import bind_session_dir, log_error_event, log_event
 from nika.utils.session import Session
 from nika.utils.session_store import SessionStore
 
-VERIFY_MAX_ATTEMPTS = 3
-VERIFY_RETRY_DELAY_SEC = 2
+VERIFY_MAX_ATTEMPTS = int(os.getenv("NIKA_VERIFY_MAX_ATTEMPTS", "3"))
+VERIFY_RETRY_DELAY_SEC = float(os.getenv("NIKA_VERIFY_RETRY_DELAY_SEC", "5"))
 
 
 def _json_safe(value: Any) -> Any:
@@ -225,8 +227,20 @@ def inject_failure(
             problems=problem_names,
             verify_result=verify_payload,
         )
+        hint = ""
+        if "[TIMEOUT]" in json.dumps(verify_payload):
+            # The verifier's container exec timed out — the fault may well be
+            # injected; the CHECK could not run (container slow/not ready).
+            hint = (
+                " NOTE: the verification command itself timed out inside the "
+                "container ('[TIMEOUT]' in details) — this is usually a "
+                "transient readiness/load issue, not a bad case: retry the "
+                "case, or raise NIKA_VERIFY_MAX_ATTEMPTS / "
+                "NIKA_VERIFY_RETRY_DELAY_SEC."
+            )
         raise RuntimeError(
-            f"Failure injection verification failed for {problem_names}: {verify_result}"
+            f"Failure injection verification failed for {problem_names}: "
+            f"{verify_result}.{hint}"
         )
 
     for failure_id, problem_name in failure_rows:


### PR DESCRIPTION
When running large batches (150 cases) with the ReAct agent (`byo.langgraph`) we've hit three problems that only show up over long runs. This PR fixed them for us in our tests. (All new settings can be tuned via environment variables, and the defaults should keep today's behavior)

**1. A run can freeze forever (byo.langgraph).** The MCP `ClientSession` has no read timeout: if one response is lost, the case blocks forever. We had a run stuck for numerous hours; the last log line was `Processing request of type ListToolsRequest`. Changes: 
- every MCP connection now has a read timeout (`NIKA_MCP_READ_TIMEOUT`, default   120s; only applied if the installed `langchain_mcp_adapters` supports it, so   older versions keep working),
- when the MCP transport fails, the tool call now raises a `ToolException`   (which the agent can retry) instead of crashing the whole case, 
- the LLM clients get explicit `timeout` and `max_retries` settings   (`NIKA_LLM_TIMEOUT` / `NIKA_LLM_RETRIES`),
- if the agent already called `submit()` successfully and then hits the   recursion limit, the case is no longer counted as crashed.

**2. Timeout messages are mistaken for command output.** When a container is slow (seems common right after a redeploy), `exec_cmd` returns the string `[TIMEOUT] ...` instead of the command's real output. Code that expects real output then fails in confusing ways, eg.:

```
Failed to parse ip -j addr output: Expecting value: line 1 column 2
```

and injection verification compares against the timeout string as if it were data. 
Changes: a new `exec_cmd_checked` (retries, then raises a clear error)  for callers that need real output, used in `get_host_ip`; the verification failure message now says explicitly when the cause was a timeout; the retry settings are tunable (`NIKA_VERIFY_MAX_ATTEMPTS` / `NIKA_VERIFY_RETRY_DELAY_SEC`; the delay default goes from 2s to 5s, because 2s was often too short for a slow container to recover).

**3. Failed cases leave their lab running.** When a case failed, its session stayed marked `running` and the Kathara lab stayed deployed; using CPU in the background and disturbing the cases that run after it. `run_single_case` now closes the session and undeploys the lab (best effort) whenever a case fails.

This commit also includes two small fixes for `--resume` correctness: 
- if a case fails *after* its run was already marked `finished` (for example failing during evaluation), it status is set back to `error`, so that `--resume` retries it; 
- if the LLM judge fails temporarily, an otherwise complete case is no longer marked failed; the judge can be re-run offline.

Runs that never hit these conditions behave exactly as before (well except the verification retry delay mentioned above).

(Another related PR will follow if this one is good for you)
