### PR TITLE
Lab lifecycle robustness + batch runner watchdog

### DIFF
--- a/src/nika/cli/README.md
+++ b/src/nika/cli/README.md
@@ -201,6 +201,17 @@ nika benchmark run --result_dir results/list1 --batch-size 4   # resume skips co
 
 **`--batch-size`**: number of YAML rows to run simultaneously per batch (default `1`). Rows are chunked into groups of this size; each group runs fully in parallel (one subprocess per row) and the next group starts only after all rows in the current group have finished. Applies to batch mode only.
 
+**`--case-timeout SECONDS`** (`NIKA_CASE_TIMEOUT`, batch mode): hard per-case time limit. When it expires, the case's entire process group is killed (agent subprocesses and docker clients included) and the case counts as failed. When set, each row runs in its own subprocess even at `--batch-size 1`, so a stuck case can be killed cleanly.
+
+**`--continue-on-error`** (`NIKA_CONTINUE_ON_ERROR`, batch mode): keep going after a failed case instead of aborting the run; failed cases are summarized at the end. Re-running the same command with `--resume` retries only the failed cases.
+
+**`--retry-passes N`** (`NIKA_RETRY_PASSES`, batch mode): after the first pass, automatically re-scan and retry failed cases up to `N` extra passes (implies `--continue-on-error`). Retries stop early when a pass completes no new case. Example for a long unattended run:
+
+```bash
+nika benchmark run --config benchmark/benchmark_selected.yaml --batch-size 4 \
+    --case-timeout 2400 --retry-passes 2
+```
+
 **YAML case fields**:
 
 | Field | Meaning |

--- a/src/nika/cli/commands/benchmark.py
+++ b/src/nika/cli/commands/benchmark.py
@@ -142,6 +142,36 @@ def benchmark_run(
             "Use --no-resume to re-run every case."
         ),
     ),
+    case_timeout: int = typer.Option(
+        0,
+        "--case-timeout",
+        envvar="NIKA_CASE_TIMEOUT",
+        help=(
+            "YAML batch mode: hard per-case watchdog in seconds (0 = disabled). "
+            "A case exceeding it is killed (whole process group) and counted as "
+            "failed instead of stalling the run forever."
+        ),
+    ),
+    continue_on_error: bool = typer.Option(
+        False,
+        "--continue-on-error/--abort-on-error",
+        envvar="NIKA_CONTINUE_ON_ERROR",
+        help=(
+            "YAML batch mode: keep running past failed cases and summarize them "
+            "at the end (default: abort on the first failure)."
+        ),
+    ),
+    retry_passes: int = typer.Option(
+        0,
+        "--retry-passes",
+        envvar="NIKA_RETRY_PASSES",
+        help=(
+            "YAML batch mode: after the first pass, automatically re-scan and "
+            "retry failed cases up to this many extra passes (implies "
+            "--continue-on-error). Stops early when a pass completes no new "
+            "case, so a deterministic bug cannot burn all passes."
+        ),
+    ),
 ) -> None:
     """Run one benchmark row from YAML, or a single case when SCENARIO and --problem are set."""
     if run_judge:
@@ -165,6 +195,18 @@ def benchmark_run(
         if batch_size != 1:
             raise typer.BadParameter(
                 "--batch-size applies to YAML batch mode only; omit it for a single case."
+            )
+        if case_timeout:
+            raise typer.BadParameter(
+                "--case-timeout applies to YAML batch mode only; omit it for a single case."
+            )
+        if continue_on_error:
+            raise typer.BadParameter(
+                "--continue-on-error applies to YAML batch mode only; omit it for a single case."
+            )
+        if retry_passes:
+            raise typer.BadParameter(
+                "--retry-passes applies to YAML batch mode only; omit it for a single case."
             )
         if not problem:
             raise typer.BadParameter("--problem is required when SCENARIO is given.")
@@ -225,4 +267,7 @@ def benchmark_run(
         result_dir=result_dir,
         resume=resume,
         session_tag=session_tag,
+        case_timeout=case_timeout,
+        continue_on_error=continue_on_error,
+        retry_passes=retry_passes,
     )

--- a/src/nika/net_env/verify.py
+++ b/src/nika/net_env/verify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
@@ -10,8 +11,11 @@ if TYPE_CHECKING:
     from nika.net_env.base import NetworkEnvBase
     from nika.runtime.base import LabRuntime
 
-LAB_VERIFY_MAX_WAIT_SEC = 180
-LAB_VERIFY_RETRY_DELAY_SEC = 5
+# Env-overridable: on a loaded host (parallel cases, container churn) labs —
+# especially DHCP-based ones — can legitimately need longer than 180s to
+# converge, and a too-short wait fails the whole case before the agent runs.
+LAB_VERIFY_MAX_WAIT_SEC = int(os.getenv("NIKA_LAB_VERIFY_MAX_WAIT", "180"))
+LAB_VERIFY_RETRY_DELAY_SEC = float(os.getenv("NIKA_LAB_VERIFY_RETRY_DELAY", "5"))
 
 
 def build_lab_verify_result(

--- a/src/nika/runtime/kathara/runtime.py
+++ b/src/nika/runtime/kathara/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,17 @@ if TYPE_CHECKING:
     from docker.models.containers import Container
 
     from nika.net_env.base import NetworkEnvBase
+
+# Lab lifecycle robustness knobs (env-overridable).
+# Deploy: transient host failures (e.g. Docker/systemd cgroup timeouts under
+# container churn) are retried after cleaning the partial deploy; readiness is
+# verified by polling instead of hoping a fixed sleep was long enough.
+DEPLOY_ATTEMPTS = int(os.getenv("NIKA_DEPLOY_ATTEMPTS", "3"))
+DEPLOY_READY_TIMEOUT_SEC = float(os.getenv("NIKA_DEPLOY_READY_TIMEOUT", "90"))
+DEPLOY_SETTLE_SEC = float(os.getenv("NIKA_DEPLOY_SETTLE", "5"))
+# Undeploy: verify the lab's containers are actually gone (a silently leaked
+# lab keeps burning CPU and skews later runs).
+UNDEPLOY_VERIFY_TIMEOUT_SEC = float(os.getenv("NIKA_UNDEPLOY_VERIFY_TIMEOUT", "30"))
 
 
 class KatharaRuntime(LabRuntime):
@@ -73,19 +85,95 @@ class KatharaRuntime(LabRuntime):
     def lab_name(self) -> str:
         return self._net_env.name or self._net_env.lab.name
 
+    def _running_machine_count(self) -> int:
+        """Number of this lab's machines with a running container."""
+        try:
+            lab = self._instance.get_lab_from_api(lab_name=self.lab_name)
+            if lab is None or lab.machines is None:
+                return 0
+            return len(lab.machines)
+        except Exception:
+            return 0
+
+    def _wait_deploy_ready(self, timeout: float) -> None:
+        """Poll until every expected machine has a running container.
+
+        Replaces hoping that a fixed sleep was long enough: on a loaded host
+        containers can take far longer than 5s to come up, and tools that
+        exec into a machine before it exists fail in confusing ways.
+        """
+        lab = self._net_env.lab
+        expected = len(lab.machines) if lab and lab.machines else 0
+        if expected == 0:
+            return
+        deadline = time.monotonic() + timeout
+        running = 0
+        while time.monotonic() < deadline:
+            running = self._running_machine_count()
+            if running >= expected:
+                return
+            time.sleep(2.0)
+        raise RuntimeError(
+            f"Lab {self.lab_name}: only {running}/{expected} machines running "
+            f"after {timeout:.0f}s (raise NIKA_DEPLOY_READY_TIMEOUT on slow hosts)"
+        )
+
     def deploy(self) -> None:
+        """Deploy the lab, verify readiness, retry transient host failures."""
         if self.exists():
             print(f"Lab {self.lab_name} exists")
             return
         self._net_env._ensure_docker_images()
-        Kathara.get_instance().deploy_lab(lab=self._net_env.lab)
-        time.sleep(5)
+
+        last_error: Exception | None = None
+        for attempt in range(1, DEPLOY_ATTEMPTS + 1):
+            try:
+                Kathara.get_instance().deploy_lab(lab=self._net_env.lab)
+                self._wait_deploy_ready(DEPLOY_READY_TIMEOUT_SEC)
+                # short settle so services inside the containers can boot
+                time.sleep(DEPLOY_SETTLE_SEC)
+                return
+            except Exception as exc:  # noqa: BLE001 - includes docker APIError
+                last_error = exc
+                print(
+                    f"Deploy of lab {self.lab_name} failed "
+                    f"(attempt {attempt}/{DEPLOY_ATTEMPTS}): {exc}"
+                )
+                # Clean the partial deploy before retrying, or the retry
+                # collides with half-started containers.
+                self.destroy()
+                if attempt < DEPLOY_ATTEMPTS:
+                    time.sleep(5.0 * attempt)
+        raise RuntimeError(
+            f"Lab {self.lab_name} failed to deploy after {DEPLOY_ATTEMPTS} attempts"
+        ) from last_error
 
     def destroy(self) -> None:
+        """Undeploy the lab and VERIFY its containers are gone."""
         try:
             self._instance.undeploy_lab(lab_name=self.lab_name)
         except Exception as exc:
             print(f"Error undeploying lab {self.lab_name}: {exc}")
+
+        deadline = time.monotonic() + UNDEPLOY_VERIFY_TIMEOUT_SEC
+        retried = False
+        while time.monotonic() < deadline:
+            leftover = self._running_machine_count()
+            if leftover == 0:
+                return
+            if not retried:
+                # one forced second attempt before we give up
+                retried = True
+                try:
+                    self._instance.undeploy_lab(lab_name=self.lab_name)
+                except Exception as exc:
+                    print(f"Error re-undeploying lab {self.lab_name}: {exc}")
+            time.sleep(2.0)
+        print(
+            f"WARNING: lab {self.lab_name} still has {self._running_machine_count()} "
+            "container(s) after undeploy — it is LEAKED and keeps consuming "
+            "resources. Clean up with `nika session close`/`kathara wipe`."
+        )
 
     def exists(self) -> bool:
         tmp_lab = self._instance.get_lab_from_api(lab_name=self.lab_name)

--- a/src/nika/workflows/benchmark/run.py
+++ b/src/nika/workflows/benchmark/run.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import signal
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -134,8 +136,14 @@ def _run_benchmark_row_subprocess(
     judge_model: str | None,
     result_dir: str | None = None,
     session_tag: str | None = None,
+    case_timeout: int = 0,
 ) -> None:
-    """Run one YAML row via a subprocess for thread-safe parallel batch execution."""
+    """Run one YAML row via a subprocess for thread-safe parallel batch execution.
+
+    ``case_timeout`` > 0 arms a hard per-case watchdog: the whole subprocess
+    group is killed when it expires, so one hung case (frozen agent, stuck
+    tool call) cannot stall the run forever.
+    """
     cli_args = _benchmark_row_cli_args(
         row,
         agent_type=agent_type,
@@ -148,17 +156,39 @@ def _run_benchmark_row_subprocess(
         result_dir=result_dir,
         session_tag=session_tag,
     )
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         [sys.executable, "-m", "nika.cli.main", "benchmark", "run", *cli_args],
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
-    )
-    output = proc.stdout
-    if proc.stderr:
-        output += proc.stderr
+        start_new_session=True,  # own process group: the watchdog kill reaps
+    )                            # docker clients/agents too, not just the CLI
+    timed_out = False
+    try:
+        output, _ = proc.communicate(timeout=case_timeout if case_timeout > 0 else None)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(proc.pid), sig)
+            except ProcessLookupError:
+                break
+            try:
+                proc.wait(timeout=15)
+                break
+            except subprocess.TimeoutExpired:
+                continue
+        output, _ = proc.communicate()
+
+    scenario = row.get("scenario", "?")
+    problem = row.get("problem", "?")
+    if timed_out:
+        raise RuntimeError(
+            f"[{scenario}/{problem}] case exceeded --case-timeout ({case_timeout}s) "
+            f"and was killed. Its lab may be leaked — check `nika session ps`. "
+            f"Output tail:\n{(output or '')[-2000:]}"
+        )
     if proc.returncode != 0:
-        scenario = row.get("scenario", "?")
-        problem = row.get("problem", "?")
         raise RuntimeError(
             f"[{scenario}/{problem}] `nika benchmark run {' '.join(cli_args)}` "
             f"exited {proc.returncode}:\n{output}"
@@ -170,35 +200,30 @@ def _run_benchmark_row_subprocess(
 def _run_benchmark_batch_parallel(
     indexed_rows: list[tuple[int, dict]],
     *,
-    agent_type: str,
-    llm_provider: str | None,
-    model: str | None,
-    max_steps: int | None,
-    run_judge: bool,
-    judge_llm_provider: str | None,
-    judge_model: str | None,
-    result_dir: str | None = None,
-    session_tag: str | None = None,
-) -> None:
-    """Run indexed rows simultaneously (one subprocess each), then return."""
-    shared_kwargs = dict(
-        agent_type=agent_type,
-        llm_provider=llm_provider,
-        model=model,
-        max_steps=max_steps,
-        run_judge=run_judge,
-        judge_llm_provider=judge_llm_provider,
-        judge_model=judge_model,
-        result_dir=result_dir,
-        session_tag=session_tag,
-    )
+    continue_on_error: bool = False,
+    **shared_kwargs,
+) -> list[str]:
+    """Run indexed rows simultaneously (one subprocess each), then return.
+
+    Returns the error messages of failed rows. With ``continue_on_error``
+    False (historic behavior) the first failure raises; otherwise failures
+    are reported and the batch keeps going.
+    """
+    failures: list[str] = []
     with ThreadPoolExecutor(max_workers=len(indexed_rows)) as pool:
         futures = [
             pool.submit(_run_benchmark_row_subprocess, row, **shared_kwargs)
             for _index, row in indexed_rows
         ]
         for future in as_completed(futures):
-            future.result()
+            try:
+                future.result()
+            except Exception as e:  # noqa: BLE001 - row errors are aggregated
+                if not continue_on_error:
+                    raise
+                print(f"CASE FAILED (continuing): {e}")
+                failures.append(str(e))
+    return failures
 
 
 def run_single_case(
@@ -316,6 +341,9 @@ def run_benchmark_from_yaml(
     result_dir: str | None = None,
     resume: bool = True,
     session_tag: str | None = None,
+    case_timeout: int = 0,
+    continue_on_error: bool = False,
+    retry_passes: int = 0,
 ) -> None:
     """
     Run benchmark cases defined in a YAML file.
@@ -326,9 +354,22 @@ def run_benchmark_from_yaml(
     completed cases are skipped and incomplete ones are cleaned. Remaining cases run
     sequentially when ``batch_size == 1`` (default), or in parallel chunks when
     ``batch_size > 1``. Re-run the same command to resume after an interruption.
+
+    ``case_timeout`` > 0 arms a hard per-case watchdog (each row then runs in
+    its own subprocess even with ``batch_size == 1``). ``continue_on_error``
+    keeps the run going past failed rows and summarizes them at the end
+    instead of aborting on the first failure. ``retry_passes`` > 0 then
+    automatically re-scans and retries the failed cases up to that many extra
+    passes (implies ``continue_on_error``); retries stop early when a full
+    pass completes no new case, so a deterministic bug cannot burn passes.
     """
     if batch_size < 1:
         raise ValueError("batch_size must be >= 1")
+    if retry_passes < 0:
+        raise ValueError("retry_passes must be >= 0")
+    if retry_passes and not continue_on_error:
+        # A retry loop is pointless if the first failure aborts the run.
+        continue_on_error = True
 
     rows = load_benchmark_yaml(benchmark_file)
 
@@ -348,35 +389,82 @@ def run_benchmark_from_yaml(
         session_tag=session_tag,
     )
 
-    _results_root, pending = scan_benchmark_cases(
-        rows=rows,
-        result_dir=result_dir,
-        resume=resume,
-    )
-    if not pending:
-        return
+    def _run_pending(pending: list[int]) -> list[str]:
+        failures: list[str] = []
+        # The watchdog needs a killable process per case, so a timeout forces
+        # the subprocess path even for sequential runs.
+        if batch_size == 1 and case_timeout <= 0:
+            for index in pending:
+                row = rows[index]
+                label = f"[{index + 1}/{len(rows)}] {row['scenario']}/{row['problem']}"
+                print(f"{label} running")
+                try:
+                    run_single_case(
+                        problem=row["problem"],
+                        scenario=row["scenario"],
+                        topo_size=row.get("topo_size") or "",
+                        inject_params=row["inject"],
+                        **_shared_kwargs,
+                    )
+                except Exception as e:  # noqa: BLE001 - row errors are aggregated
+                    if not continue_on_error:
+                        raise
+                    print(
+                        f"CASE FAILED (continuing): [{row['scenario']}/{row['problem']}] {e}"
+                    )
+                    failures.append(f"[{row['scenario']}/{row['problem']}] {e}")
+        else:
+            for chunk_start in range(0, len(pending), batch_size):
+                chunk_indices = pending[chunk_start : chunk_start + batch_size]
+                indexed_rows = [(index, rows[index]) for index in chunk_indices]
+                first = chunk_indices[0] + 1
+                last = chunk_indices[-1] + 1
+                print(
+                    f"[batch {chunk_start // batch_size + 1}] running {len(chunk_indices)} session(s) in parallel "
+                    f"(rows {first}–{last} of {len(rows)})"
+                )
+                failures += _run_benchmark_batch_parallel(
+                    indexed_rows,
+                    continue_on_error=continue_on_error,
+                    case_timeout=case_timeout,
+                    **_shared_kwargs,
+                )
+        return failures
 
-    if batch_size == 1:
-        for index in pending:
-            row = rows[index]
-            label = f"[{index + 1}/{len(rows)}] {row['scenario']}/{row['problem']}"
-            print(f"{label} running")
-            run_single_case(
-                problem=row["problem"],
-                scenario=row["scenario"],
-                topo_size=row.get("topo_size") or "",
-                inject_params=row["inject"],
-                **_shared_kwargs,
-            )
-        return
-
-    for chunk_start in range(0, len(pending), batch_size):
-        chunk_indices = pending[chunk_start : chunk_start + batch_size]
-        indexed_rows = [(index, rows[index]) for index in chunk_indices]
-        first = chunk_indices[0] + 1
-        last = chunk_indices[-1] + 1
-        print(
-            f"[batch {chunk_start // batch_size + 1}] running {len(chunk_indices)} session(s) in parallel "
-            f"(rows {first}–{last} of {len(rows)})"
+    failures: list[str] = []
+    previous_pending: int | None = None
+    for attempt in range(retry_passes + 1):
+        _results_root, pending = scan_benchmark_cases(
+            rows=rows,
+            result_dir=result_dir,
+            # Retry passes must skip completed cases regardless of --no-resume.
+            resume=resume or attempt > 0,
         )
-        _run_benchmark_batch_parallel(indexed_rows, **_shared_kwargs)
+        if not pending:
+            if attempt > 0:
+                print("\nAll benchmark cases completed after retries.")
+            return
+        if attempt > 0:
+            if previous_pending is not None and len(pending) >= previous_pending:
+                print(
+                    f"\nRetry made no progress ({len(pending)} case(s) still "
+                    "failing deterministically); stopping retries."
+                )
+                break
+            print(
+                f"\n[retry {attempt}/{retry_passes}] retrying {len(pending)} failed case(s)"
+            )
+        previous_pending = len(pending)
+        failures = _run_pending(pending)
+        if not failures:
+            if attempt > 0:
+                print("\nAll benchmark cases completed after retries.")
+            return
+
+    if failures:
+        print(
+            f"\n{len(failures)} case(s) still FAILED "
+            "(re-run the same command with --resume to retry only these):"
+        )
+        for message in failures:
+            print(f"  - {message.splitlines()[0]}")

--- a/src/nika/workflows/env/start.py
+++ b/src/nika/workflows/env/start.py
@@ -114,6 +114,16 @@ def start_net_env(
             error=str(exc),
             error_type=type(exc).__name__,
         )
+        # A failed start must not strand the lab we just deployed: with one
+        # leaked lab per failed verification, a long benchmark run piles up
+        # dozens of running container sets.
+        try:
+            net_env.undeploy()
+        except Exception as cleanup_exc:  # noqa: BLE001 - best effort
+            print(
+                f"WARNING: could not undeploy lab {net_env.name} after "
+                f"failed start: {cleanup_exc}"
+            )
         raise
 
     log_event(


### PR DESCRIPTION
Follow-up to #25, as promised, based on experience from the same 150-case benchmark campaign. Two things:

**Lab deploy/undeploy (`0b5d19f`).** Deploy was `deploy_lab` followed by a fixed 5-second sleep. Two problems:
- On a loaded host, containers can take much longer than 5s to come up. A tool that runs a command in a machine too early then fails with a confusing error (even though nothing is actually wrong with the lab). 
- A temporary host-side failure during deploy killed the case immediately. A concrete example we faced when many containers start and stop at once:
  `Timeout waiting for systemd to create docker-<id>.scope`.

Now, deploy polls until every expected machine has a running container (`NIKA_DEPLOY_READY_TIMEOUT`, default 90s), retries a failed deploy after cleaning up the partial one (`NIKA_DEPLOY_ATTEMPTS`, default 3), and keeps a short settle delay (`NIKA_DEPLOY_SETTLE`).

Small related change in the same commit: the lab verification wait knobs keep their defaults (180s max wait, 5s retry delay) but are now env-overridable (`NIKA_LAB_VERIFY_MAX_WAIT` / `NIKA_LAB_VERIFY_RETRY_DELAY`), because on a loaded host some labs may need more than 180s to converge.

Undeploy had the opposite problem: it ignored every error and never checked that the lab was actually gone. A lab that survives undeploy keeps using CPU in the background and disturbs the cases that run after it, and nothing tells us about it. Now, undeploy verifies the containers are gone (`NIKA_UNDEPLOY_VERIFY_TIMEOUT`, default 30s), tries a second time if not, and prints a clear warning with instructions if the lab is still alive after that. In the same spirit, a lab that deploys fine but then fails verification is now undeployed instead of left running (before, every failed verification leaked one full container set for the rest of the run).

**Batch runner (`19f190e`).** #25 made a failed case clean and resumable: the session is closed, the lab undeployed, and `--resume` retries it. But the exception still propagates by design, so the run itself still stops at the first failed case (`future.result()` re-raises and the remaining cases never start). Likewise for hangs: #25 fixed the specific causes we found (MCP read timeouts, the exec sentinel), but there is still no upper bound on how long one case may run, so an unknown cause would still stall the run forever. Three opt-in flags close these batch-level gaps; without them, behavior is unchanged: 
- `--case-timeout SECONDS` (`NIKA_CASE_TIMEOUT`): a hard per-case time limit. When it expires, the case's entire process group is killed (including docker clients and agent subprocesses) and the case is counted as failed. When a timeout is set, each row runs in its own subprocess even at `--batch-size 1` (because that's what makes it possible to kill a stuck case cleanly).
- `--continue-on-error` (`NIKA_CONTINUE_ON_ERROR`): keep going after a failed case and print a summary of the failures at the end. Together with `--resume`, re-running the same command retries only the failed cases.
- `--retry-passes N` (`NIKA_RETRY_PASSES`): after the first pass, automatically re-scan and retry the failed cases up to N extra passes (implies `--continue-on-error`). A pass that completes no new case stops the retries early, so a deterministic bug cannot burn all the passes. This turns an overnight 150-case run into one command instead of a run plus manual `--resume` reruns in the morning.

The three flags are also documented in the batch mode section of `src/nika/cli/README.md` (`f689763`), next to `--resume` and `--batch-size`.
