### PR TITLE
Restore README Features section and simplify Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,75 +61,73 @@ NIKA's problem registry defines the injectable root causes available in the benc
 
 #### Failure details
 
-NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
-
-<details>
-<summary>Toggle to see all 59 failure types in details 🔍</summary>
-
-| Category | Problem ID | Description | # Cases |
-| -------- | ---------- | ----------- | ------- |
-| `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
-| `end_host_failure` | `host_crash` | host_crash | 28 |
-| `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
-| `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
-| `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
-| `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
-| `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
-| `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
-| `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
-| `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
-| `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
-| `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
-| `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
-| `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
-| `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
-| `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
-| `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
-| `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
-| `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
-| `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
-| `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
-| `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
-| `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
-| `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
-| `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
-| `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
-| `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
-| `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
-| `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
-| `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
-| `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
-| `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
-| `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
-| `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
-| `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
-| `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
-| `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
-| `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
-| `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
-| `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
-| `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
-| `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
-| `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
-| `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
-| `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
-| `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
-| `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
-| `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
-| `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
-| `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
-| `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
-| `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
-| `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
-| `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
-| `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
-| `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
-| `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
-| `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
-| `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
-| **Total** | - | - | **702** |
-
-</details>
+> [!TIP]- Show all failure types
+>
+> NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
+>
+> | Category | Problem ID | Description | # Cases |
+> | -------- | ---------- | ----------- | ------- |
+> | `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
+> | `end_host_failure` | `host_crash` | host_crash | 28 |
+> | `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
+> | `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
+> | `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
+> | `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
+> | `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
+> | `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
+> | `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
+> | `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
+> | `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
+> | `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
+> | `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
+> | `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
+> | `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
+> | `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
+> | `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
+> | `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
+> | `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
+> | `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
+> | `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
+> | `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
+> | `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
+> | `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
+> | `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
+> | `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
+> | `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
+> | `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
+> | `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
+> | `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
+> | `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
+> | `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
+> | `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
+> | `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
+> | `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
+> | `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
+> | `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
+> | `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
+> | `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
+> | `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
+> | `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
+> | `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
+> | `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
+> | `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
+> | `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
+> | `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
+> | `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
+> | `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
+> | `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
+> | `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
+> | `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
+> | `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
+> | `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
+> | `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
+> | `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
+> | `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
+> | `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
+> | `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
+> | `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
+> | **Total** | - | - | **702** |
+>
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -61,73 +61,75 @@ NIKA's problem registry defines the injectable root causes available in the benc
 
 #### Failure details
 
-> [!TIP]- Show all failure types
->
-> NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
->
-> | Category | Problem ID | Description | # Cases |
-> | -------- | ---------- | ----------- | ------- |
-> | `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
-> | `end_host_failure` | `host_crash` | host_crash | 28 |
-> | `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
-> | `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
-> | `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
-> | `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
-> | `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
-> | `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
-> | `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
-> | `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
-> | `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
-> | `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
-> | `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
-> | `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
-> | `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
-> | `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
-> | `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
-> | `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
-> | `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
-> | `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
-> | `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
-> | `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
-> | `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
-> | `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
-> | `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
-> | `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
-> | `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
-> | `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
-> | `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
-> | `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
-> | `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
-> | `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
-> | `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
-> | `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
-> | `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
-> | `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
-> | `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
-> | `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
-> | `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
-> | `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
-> | `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
-> | `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
-> | `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
-> | `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
-> | `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
-> | `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
-> | `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
-> | `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
-> | `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
-> | `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
-> | `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
-> | `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
-> | `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
-> | `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
-> | `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
-> | `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
-> | `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
-> | `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
-> | `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
-> | **Total** | - | - | **702** |
->
+NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
+
+<details>
+<summary>Show all failure types</summary>
+
+| Category | Problem ID | Description | # Cases |
+| -------- | ---------- | ----------- | ------- |
+| `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
+| `end_host_failure` | `host_crash` | host_crash | 28 |
+| `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
+| `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
+| `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
+| `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
+| `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
+| `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
+| `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
+| `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
+| `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
+| `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
+| `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
+| `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
+| `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
+| `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
+| `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
+| `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
+| `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
+| `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
+| `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
+| `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
+| `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
+| `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
+| `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
+| `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
+| `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
+| `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
+| `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
+| `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
+| `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
+| `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
+| `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
+| `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
+| `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
+| `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
+| `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
+| `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
+| `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
+| `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
+| `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
+| `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
+| `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
+| `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
+| `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
+| `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
+| `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
+| `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
+| `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
+| `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
+| `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
+| `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
+| `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
+| `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
+| **Total** | - | - | **702** |
+
+</details>
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It helps different users answer questions like:
 - 💬 **Network SRE** "I respond to network incidents every day. I want an AI agent to help, but I'm not sure it will understand my topology or make things worse."
 - 💬 **AI Researcher** "I'm designing a new harness for long-horizon network tasks. I need a benchmark to ablate components, measure reproducibly, and compare against published baselines."
 - 💬 **Applied ML Engineer** "I want to fine-tune an open-source model on network troubleshooting and need a structured dataset paired with a rigorous evaluation framework."
-- 💬 **Open-Source Contributor** "I want to contribute a new network scenario or fault type to the community and have it evaluated systematically."
+- 💬 **Contributor** "I want to contribute a new network scenario or fault type to the community and have it evaluated systematically."
 
 ## 🤖 Overview
 
@@ -43,11 +43,9 @@ NIKA combines two components:
 1. **NIKA Benchmark** — a suite of reproducible incidents defined by a network scenario and an injectable root cause. The full working matrix contains 15 scenarios, 59 fault types, and 702 cases.
 2. **NIKA Orchestrator** — a modular platform that deploys live labs, injects faults, connects agents to interactive MCP tools, and evaluates their submissions.
 
-NIKA supports Kathará and Containerlab backends, multiple agent frameworks, native CLI agents, sandboxed execution, and MCP-based network diagnostics. The implementation and configuration details are linked in [Learn more](#-learn-more).
+### Network incidents
 
-### Failure types
-
-NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced across multiple network topologies and traffic scenarios, for a total of 702 unique cases.
+Network incidents in the NIKA's benchmark is constructed starting from recurring root cause failures, drawn from the following categories: 
 
 | Category | Fault types | # Cases |
 | --- | :---: | :---: |
@@ -59,12 +57,11 @@ NIKA's problem registry defines the injectable root causes available in the benc
 | Resource contention | 8 | 119 |
 | **Total** | **59** | **702** |
 
-#### Failure details
-
-NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
-
 <details>
-<summary>Show all failure types</summary>
+<summary>🔍 <strong>Show all 59 failure types</strong></summary>
+
+NIKA's benchmark is constructed from a set of common the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
+
 
 | Category | Problem ID | Description | # Cases |
 | -------- | ---------- | ----------- | ------- |
@@ -130,6 +127,7 @@ NIKA's problem registry defines the injectable root causes available in the benc
 | **Total** | - | - | **702** |
 
 </details>
+
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <br />
 
 [🤖 Overview](#-overview) ·
+[✨ Features](#-features) ·
 [📦 Installation](#-installation) ·
 [🚀 Quick start](#-quick-start) ·
 [📖 Learn more](#-learn-more) ·
@@ -19,7 +20,7 @@
 
 ## ❓ What is NIKA?
 
-Think about [SWE-Bench](https://github.com/swe-bench/SWE-bench), but for network troubleshooting. [NIKA](https://sands-lab.github.io/nika/), **N**etwork **I**ncident Benchmar**k** for **A**I Agents, is an *open benchmark for agentic evals on network troubleshooting tasks*. It connects any agent directly to a live network stack: routers, switches, hosts, and telemetry tools, all running on general-purpose compute. NIKA reproduces hundreds of realistic faults covering data center networks, campus networks, ISP backbones, SDN fabrics, overlay networks, and Kubernetes CNIs.
+Think about [SWE-Bench](https://github.com/swe-bench/SWE-bench), but for network troubleshooting. [NIKA](https://sands-lab.github.io/nika/), **N**etwork **I**ncident Benchmar**k** for **A**I Agents, is an *open benchmark for agentic evals on network troubleshooting tasks*. NIKA reproduces hundreds of realistic faults covering data center networks, campus networks, ISP backbones, SDN fabrics, overlay networks, and Kubernetes CNIs. It connects any agent directly to a live network stack while the incident is ongoing: routers, switch CLIs, and telemetry tools, all running in your machine powered by state-of-the-art network emulation backends. 
 
 ## 🙋 Why NIKA?
 
@@ -28,9 +29,9 @@ NIKA lets you plug in any LLM or agent framework and measure its operational cap
 It helps different users answer questions like:
 
 - 💬 **Network Manager** "A vendor is pitching me an AI solution for network operations. It passes all the standard telecom benchmarks (TeleQnA, TeleLogs, TeleMath, 3GPP-TSG), but I need objective evidence it can handle real incidents before I sign off."
-- 💬 **Network Engineer and SREs** "I respond to network incidents every day. I want an AI agent to help, but I'm not sure it will understand my topology or make things worse."
-- 💬 **AI Researcher** "I'm designing a new agent architecture for long-horizon network tasks. I need a benchmark to ablate components, measure reproducibly, and compare against published baselines."
-- 💬 **AI/ML Engineer** "I want to fine-tune an open-source model on network troubleshooting and need a structured dataset paired with a rigorous evaluation framework."
+- 💬 **Network SRE** "I respond to network incidents every day. I want an AI agent to help, but I'm not sure it will understand my topology or make things worse."
+- 💬 **AI Researcher** "I'm designing a new harness for long-horizon network tasks. I need a benchmark to ablate components, measure reproducibly, and compare against published baselines."
+- 💬 **Applied ML Engineer** "I want to fine-tune an open-source model on network troubleshooting and need a structured dataset paired with a rigorous evaluation framework."
 - 💬 **Open-Source Contributor** "I want to contribute a new network scenario or fault type to the community and have it evaluated systematically."
 
 ## 🤖 Overview
@@ -39,62 +40,139 @@ It helps different users answer questions like:
 
 NIKA combines two components:
 
-1. **NIKA Benchmark** — a suite of reproducible incidents defined by a network scenario and an injectable root cause. The full working matrix contains 15 scenarios, 56 fault types, and 702 cases.
+1. **NIKA Benchmark** — a suite of reproducible incidents defined by a network scenario and an injectable root cause. The full working matrix contains 15 scenarios, 59 fault types, and 702 cases.
 2. **NIKA Orchestrator** — a modular platform that deploys live labs, injects faults, connects agents to interactive MCP tools, and evaluates their submissions.
 
 NIKA supports Kathará and Containerlab backends, multiple agent frameworks, native CLI agents, sandboxed execution, and MCP-based network diagnostics. The implementation and configuration details are linked in [Learn more](#-learn-more).
 
-### Network operations benchmark landscape
+### Failure types
 
-| Benchmark                                                             | Type                | Supported scenarios                                                                 | Evaluation environment                                           | Supported agent types                                              | Agent isolation                                                | Parallel execution    |
-| --------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------- | --------------------- |
-| **NIKA**                                                              | **Dynamic**         | Data center, campus, ISP, SDN, P4, overlay, and Kubernetes | Live Kathará and Containerlab labs; MCP tools                              | LangGraph, AutoGen, MCP Agent, custom Python agents, Codex, Claude | [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/get-started/)   | ✓       |
-| [NetOpsBench](https://github.com/NetX-lab/NetOpsBench)                | **Dynamic**         | Data-center leaf-spine fabrics at XS, Small, Medium, and Large scales                                    | Live Containerlab and SONiC-VS; MCP and telemetry tools                    | Custom Python troubleshooting agents                               | Not documented                                                 | ✓            |
-| [NetArena](https://github.com/Froot-NetSys/NetArena)                  | **Dynamic**         | Data-center capacity planning, routing, and Kubernetes microservice-policy scenarios                     | Dynamically generated emulation and Kubernetes environments; A2A interface | A2A-compatible agents                                              | Optional Docker deployment                                     | Not documented        |
-| [AIOpsLab](https://github.com/microsoft/AIOpsLab)                     | **Dynamic**         | Kubernetes microservices with injected application and infrastructure faults                             | Live Kubernetes applications, workloads, telemetry, and orchestrator APIs  | Custom Python and remote agents                                    | Not documented                                                 | Not documented        |
-| [ITBench](https://github.com/itbench-hub/ITBench)                     | **Dynamic**         | Kubernetes-based SRE, security, compliance, and FinOps scenarios                                         | Managed live environments with natural-language tools                      | Externally operated agents                                         | Agents run externally                                          | Not documented        |
-| [Cornetto](https://arxiv.org/abs/2604.22513)                          | **Static**          | Synthesized networks with 20–754 nodes; 231 configuration-repair problems                                | Offline formal network verification                                        | LLMs and configuration-repair methods                              | Not applicable                                                 | Not documented        |
-| [NetConfEval](https://github.com/RedHatResearch/conext24-NetConfEval) | **Static**          | Routing, API generation, formal specifications, and device configurations                                | Pre-generated tasks with offline validation                                | Configurable LLM backends                                          | Not applicable                                                 | Not documented        |
-| [GSMA Open Telco](https://huggingface.co/datasets/GSMA/ot-full)       | **Static**          | Telecom knowledge, standards, logs, O-RAN, srsRAN, and 6G tasks                                          | 20,588 samples across eight datasets                                       | Models supported by Inspect AI                                     | Not applicable                                                 | Not documented        |
-| [WirelessBench](https://wirelessbench.github.io/)                     | **Static**          | Wireless calculations, 5G slicing, and mobility-aware allocation                                         | 848 validation and 2,544 test samples; offline domain tools                | LLMs and reference agents                                          | Not applicable                                                 | Not documented        |
-| [TeleLogsAgent](https://huggingface.co/datasets/netop/TeleLogsAgent)  | **Static tool-use** | 5G drive-test, radio KPI, mobility, signaling, and throughput scenarios                                  | Fixed data exposed through HTTP or MCP tools                               | OpenAI-compatible models and MCP agents                            | Not documented                                                 | Not documented        |
-| [NetInjectBench](https://arxiv.org/abs/2607.10490)                    | **Static tool-use** | 130 benign, prompt-injection, and approved-change network scenarios                                      | Six simulated network-operations tools                                     | Evaluated models and defense methods                               | Not applicable                                                 | Not documented        |
-| [Multi-modal Wi-Fi Fault Diagnosis](https://arxiv.org/abs/2605.22008) | **Static**          | Campus Wi-Fi testbed and 11 cross-layer fault categories                                                 | More than 10,000 samples collected from a campus Wi-Fi testbed             | Multi-modal diagnostic models                                      | Not applicable                                                 | Not documented        |
+NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced across multiple network topologies and traffic scenarios, for a total of 702 unique cases.
 
-`Dynamic` benchmarks let agents observe or modify a running environment. `Static` benchmarks evaluate pre-collected or generated samples. `Static tool-use` benchmarks use fixed scenarios but expose them through simulated or local tools.
+| Category | Fault types | # Cases |
+| --- | :---: | :---: |
+| End-host failures | 9 | 161 |
+| Link failures | 7 | 129 |
+| Misconfigurations | 11 | 169 |
+| Network node errors | 11 | 65 |
+| Network under attack | 6 | 59 |
+| Resource contention | 8 | 119 |
+| **Total** | **59** | **702** |
+
+#### Failure details
+
+NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
+
+<details>
+<summary>Toggle to see all 59 failure types in details 🔍</summary>
+
+| Category | Problem ID | Description | # Cases |
+| -------- | ---------- | ----------- | ------- |
+| `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
+| `end_host_failure` | `host_crash` | host_crash | 28 |
+| `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
+| `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
+| `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
+| `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
+| `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
+| `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
+| `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
+| `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
+| `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
+| `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
+| `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
+| `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
+| `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
+| `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
+| `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
+| `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
+| `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
+| `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
+| `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
+| `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
+| `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
+| `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
+| `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
+| `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
+| `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
+| `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
+| `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
+| `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
+| `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
+| `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
+| `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
+| `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
+| `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
+| `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
+| `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
+| `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
+| `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
+| `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
+| `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
+| `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
+| `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
+| `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
+| `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
+| `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
+| `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
+| `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
+| `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
+| `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
+| `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
+| `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
+| `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
+| `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
+| **Total** | - | - | **702** |
+
+</details>
+
+## ✨ Features
+
+- **Network emulators**: NIKA attaches to state-of-the-art network emulators as backends. Are you a [Kathará](https://www.kathara.org) or [Containerlab](https://containerlab.dev) user? You can use NIKA with both.
+- **Pre-built incident scenarios**: Running evals to benchmark AI agents has never been so simple. Start one of the pre-built network scenarios, with automatic evaluation mechanism.
+- **Bring any AI agent**: Easy integration of custom AI agents, see [Agent integration workflow](docs/custom-agents.md).
+- **Agent sandboxing**: Agents run in isolated environments, with controlled access to the network, filesystem and telemetry tools, see [Agent sandboxing](docs/agent-sandbox.md).
+- **YAML-based fault injection**: Failures can be customized declaratively: `nika failure describe`, and later `--set key=value`.
+- **MCP network telemetry**: Pingmesh server, InfluxDB network telemetry and CLI access to routers and switches.
+- **Multi-session evals**: Session-based workflow with multi-session support (`nika session`, `--session_id`). Run isolated sessions in parallel to speed up evaluations.
+- **Remote execution**: Run agents locally while the emulated network and MCP gateways can run on a remote host with compute capacity, see [NIKA Remote](docs/remote.md).
+- **Reproducibility and leaderboard**: Frozen `nika-bench` releases, submit to the real-time leaderboard.
+- **NIKA SDK**: Extend with your own network topology and configuration, and reproduce your failure case using NIKA's modules for traffic generation and fault injection, see [Creating benchmark tasks](docs/creating-benchmark-tasks.md).
 
 
 ## 📦 Installation
 
-NIKA requires Linux and Python 3.12+. Dependency management uses [uv](https://docs.astral.sh/uv/).
+**Requirements**: Python 3.12+, and [uv](https://docs.astral.sh/uv/) for dependency management. 
+Additionally, NIKA needs Docker and at least one network emulation backend. Currently supported backends are:
 
-Core install (agent CLI and evaluation; no local lab backends):
+- **[Kathará](https://www.kathara.org/)** — install with `--extra kathara` option below.
+- **[Containerlab](https://containerlab.dev/)** — install with `--extra containerlab` option below.
+- **Both** — install with `--extra labs` option below.
+
+### Basic setup
 
 ```shell
 git clone https://github.com/sands-lab/nika
 cd nika
-uv sync
+uv sync --extra labs   # or --extra kathara / --extra containerlab / (no extra)
 source .venv/bin/activate
 cp .env.example .env
 ```
 
-Local lab deployment needs Docker plus at least one backend extra:
+### API keys and credentials
 
-| Extra | Provides | Also requires |
-|-------|----------|---------------|
-| `kathara` | [Kathará](https://www.kathara.org/) Python API, Docker SDK, Kubernetes client | Docker |
-| `containerlab` | Docker SDK for [Containerlab](https://containerlab.dev/) labs | Docker, `clab` on `PATH` (`gnmic` for SRL) |
-| `labs` | Both of the above | Same as each backend |
+- Add the model credentials and agent settings you need to `.env`. 
+- CLI flags override `.env` values. 
 
-```shell
-uv sync --extra labs          # local Kathara + Containerlab
-# or: uv sync --extra kathara
-# or: uv sync --extra containerlab
-```
+### Remote Deployments:
 
-Add the model credentials and agent settings you need to `.env`. CLI flags override `.env` values. Sandbox-backed agents also require `sbx login`, KVM, and the appropriate optional dependency group; see the [agent sandbox guide](docs/agent-sandbox.md).
-
-To run labs on a separate machine, see [NIKA Remote](docs/remote.md).
+- **Agent Sandboxing**: See the [agent sandbox guide](docs/agent-sandbox.md) for sandboxed execution requirements.
+- **Remote Mode**: This is useful if you do not want to install an emulation backend on your machine, or/and if you want to scale the emulated network to many virtual nodes on a high-capacity server, while running the agent locally. Please follow [Remote Agent Mode](docs/remote.md) documentation for more details.
 
 ## 🚀 Quick start
 
@@ -132,26 +210,42 @@ Benchmark runs deploy the lab, inject the fault, run the selected agent, close t
 
 ## 📖 Learn more
 
-**Run and evaluate**
+Pick the path that matches what you're trying to do:
 
-- [CLI reference](src/nika/cli/README.md) — commands, options, sessions, and result paths.
-- [Benchmark guide](benchmark/README.md) — releases, custom cases, parallel execution, and resume behavior.
-- [Testing guide](tests/README.md) — test suites and their external prerequisites.
+**🏁 I want to run the benchmark, any agent**
 
-**Build and extend**
+1. [Quick start](#-quick-start) — deploy a lab, inject a fault, run an agent, evaluate.
+2. [CLI reference](src/nika/cli/README.md) — `nika` commands, sessions, and result paths.
+3. [Leaderboard submission](docs/leaderboard-submission.md)
 
-- [Agent architecture](src/agent/README.md) — built-in agents and configuration.
-- [Custom agents](docs/custom-agents.md) — agent contract and integration workflow.
-- [Agent sandbox](docs/agent-sandbox.md) — isolated microVM execution.
-- [Agent skills](docs/agent-skills.md) — reusable troubleshooting knowledge.
-- [Creating benchmark tasks](docs/creating-benchmark-tasks.md) — scenarios, faults, traffic, and cases.
+**🔌 I want to connect my own agent**
 
-**Share results**
+1. [Built-in agents](src/agent/README.md) — built-in agents and configuration, for reference implementations.
+2. [Agent integration workflow](docs/custom-agents.md) — agent contract and integration workflow.
+3. [Agent skills](docs/agent-skills.md) — reusable troubleshooting knowledge you can attach to an agent.
+3. [Agent sandboxing](docs/agent-sandbox.md) — isolated microVM execution.
 
-- [Leaderboard submission](docs/leaderboard-submission.md) — package, validate, and submit an official run.
-- [NIKA Zenodo dataset](https://zenodo.org/records/17971675) — public agent troubleshooting traces.
+**🌐 I want to create a new network scenario**
 
-The complete environment template is [`.env.example`](.env.example).
+1. [Creating benchmark tasks](docs/creating-benchmark-tasks.md)
+2. [Network incidents](docs/failure-types.md)
+3. [Testing guide](tests/README.md)
+
+
+## Network management benchmarks
+
+NIKA is part of a growing ecosystem of network operations benchmarks. The table below compares NIKA with other benchmarks in terms of their focus, agent interactivity, variety, scale, and realism. While the best benchmark depends on your use case, NIKA is currently the most comprehensive benchmark among those that provides a live network environment for agentic evaluations.
+
+| Benchmark | Description | Variety | Scale | Environment Realism | Online Agent? | Best for |
+|---|---|:---:|:---:|:---:|:---:|---|
+| **[NIKA]((https://sands-lab.github.io/nika))** | Live network troubleshooting | ⭐️⭐️⭐️ <br> 59 fault types <br> 6 networks types | ⭐️⭐️ <br> ~700 incident variants | ⭐️⭐️⭐️ <br> ✔ Kathará/Containerlab emulation <br> ✔ Vendor CLIs & telemetry tools | ✅ | Agentic evals |
+| [NetOpsBench](https://github.com/NetX-lab/NetOpsBench) | Live network troubleshooting | ⭐️ <br> 13 fault types <br> 1 network type | ⭐️⭐️ <br>~600 incident variants | ⭐️⭐️⭐️ <br> ✔ Containerlab emulation <br> ✔ Vendor CLIs & telemetry tools | ✅ | Agentic evals |
+| [NetArena](https://github.com/Froot-NetSys/NetArena) | Network operations benchmark | ⭐️ <br> 3 types<br>lab-style topologies | ⭐️⭐️⭐️ <br> ~9,000 variants | ⭐️⭐️ <br>Mininet <br> Basic netutils (e.g., ping) | ✅ | Large-scale synthetic variants for ML |
+| [NetConfEval](https://github.com/RedHatResearch/conext24-NetConfEval) | Config exercises | ⭐️ <br> Misconfigurations only | ⭐️⭐️⭐️ <br> ~3,000 exercises | ⭐️ <br> Simple validator | ❌ | Basic LLM config-generation capability |
+| [Cornetto](https://arxiv.org/abs/2604.22513) | Config-repair with formal verification | ⭐️ <br> Misconfigurations only | ⭐️⭐️ <br> 231 problems | ⭐️ <br> Batfish | ❌ | LLM config repair |
+| [GSMA Open Telco](https://huggingface.co/datasets/GSMA/ot-full) | Q&A telecom knowledge | ⭐️⭐️ <br> Multiple telecom datasets | ⭐️⭐️⭐️ <br> 20,588 samples | ⭐️ <br> Simple validator | ❌ | Basic LLM telecom knowledge |
+
+**Notes:** `Online` benchmarks (3rd column) let agents observe or modify a running environment. `Offline` benchmarks evaluate pre-collected or generated samples. 
 
 ## 📚 Citation
 

--- a/docs/failure-types.md
+++ b/docs/failure-types.md
@@ -1,0 +1,69 @@
+# Failure types
+
+NIKA's problem registry defines the injectable root causes available in the benchmark. Each problem has been reproduced in multiple network topologies and traffic scenarios, resulting in a total of 702 unique cases. The table below lists the problem categories, IDs, descriptions, and the number of cases for each problem.
+
+
+| Category | Problem ID | Description | # Cases |
+| -------- | ---------- | ----------- | ------- |
+| `end_host_failure` | `dns_record_error` | Some hosts cannot access external websites. | 6 |
+| `end_host_failure` | `host_crash` | host_crash | 28 |
+| `end_host_failure` | `host_incorrect_dns` | Some hosts are unable to access web services. | 6 |
+| `end_host_failure` | `host_incorrect_gateway` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_incorrect_ip` | Some hosts seem to be unreachable in the network. | 28 |
+| `end_host_failure` | `host_incorrect_netmask` | Some hosts seem to be unreachable in the network. | 17 |
+| `end_host_failure` | `host_ip_conflict` | Some hosts experience intermittent connectivity issues. | 28 |
+| `end_host_failure` | `host_missing_ip` | Some hosts are unable to communicate with other devices in the network. | 28 |
+| `end_host_failure` | `host_vpn_membership_missing` | host_vpn_membership_missing | 3 |
+| `link_failure` | `bmv2_switch_down` | bmv2_switch_down | 4 |
+| `link_failure` | `dhcp_service_down` | dhcp_service_down | 3 |
+| `link_failure` | `dns_service_down` | Some hosts cannot access external websites. | 6 |
+| `link_failure` | `link_detach` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_down` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_flap` | Users report connectivity issues to other hosts. | 29 |
+| `link_failure` | `link_fragmentation_disabled` | Users report partial packet loss when communicating with other hosts. | 29 |
+| `misconfiguration` | `arp_acl_block` | arp_acl_block | 28 |
+| `misconfiguration` | `bgp_acl_block` | bgp_acl_block | 9 |
+| `misconfiguration` | `bgp_asn_misconfig` | Some hosts are experiencing connectivity issues. | 9 |
+| `misconfiguration` | `bgp_blackhole_route_leak` | bgp_blackhole_route_leak | 9 |
+| `misconfiguration` | `bgp_missing_route_advertisement` | bgp_missing_route_advertisement | 9 |
+| `misconfiguration` | `dhcp_missing_subnet` | dhcp_missing_subnet | 3 |
+| `misconfiguration` | `dns_port_blocked` | dns_port_blocked | 6 |
+| `misconfiguration` | `host_static_blackhole` | host_static_blackhole | 9 |
+| `misconfiguration` | `http_acl_block` | http_acl_block | 13 |
+| `misconfiguration` | `icmp_acl_block` | icmp_acl_block | 28 |
+| `misconfiguration` | `k8s_coredns_isolated` | Applications cannot resolve Kubernetes service names such as *.svc.cluster.local and report DNS timeouts, while communication by IP address keeps working. The CoreDNS pods are Running and Ready and the DNS Service still lists its endpoints. | 0 |
+| `misconfiguration` | `k8s_worker_apiserver_partition` | One Kubernetes worker node reports NotReady and stops receiving new pods, and `kubectl exec` / `kubectl logs` time out for the pods it hosts, while those pods keep serving traffic and the node itself is still reachable over the network. | 0 |
+| `misconfiguration` | `mac_address_conflict` | mac_address_conflict | 28 |
+| `misconfiguration` | `ospf_acl_block` | ospf_acl_block | 6 |
+| `misconfiguration` | `ospf_area_misconfiguration` | ospf_area_misconfiguration | 6 |
+| `misconfiguration` | `ospf_neighbor_missing` | ospf_neighbor_missing | 6 |
+| `network_node_error` | `flow_rule_loop` | flow_rule_loop | 6 |
+| `network_node_error` | `flow_rule_shadowing` | flow_rule_shadowing | 6 |
+| `network_node_error` | `frr_service_down` | Users report connectivity issues to other hosts in the network. | 17 |
+| `network_node_error` | `k8s_clusterip_routing_broken` | Pods scheduled on one Kubernetes node cannot reach any ClusterIP Service, including in-cluster DNS, while direct pod-IP traffic from the same node still works. Services, endpoints and pods all report healthy, and the node stays Ready. | 0 |
+| `network_node_error` | `mpls_label_limit_exceeded` | mpls_label_limit_exceeded | 1 |
+| `network_node_error` | `p4_aggressive_detection_thresholds` | p4_aggressive_detection_thresholds | 1 |
+| `network_node_error` | `p4_compilation_error_parser_state` | p4_compilation_error_parser_state | 4 |
+| `network_node_error` | `p4_header_definition_error` | p4_header_definition_error | 4 |
+| `network_node_error` | `p4_table_entry_misconfig` | p4_table_entry_misconfig | 4 |
+| `network_node_error` | `p4_table_entry_missing` | p4_table_entry_missing | 4 |
+| `network_node_error` | `sdn_controller_crash` | sdn_controller_crash | 6 |
+| `network_node_error` | `southbound_port_block` | southbound_port_block | 6 |
+| `network_node_error` | `southbound_port_mismatch` | southbound_port_mismatch | 6 |
+| `network_under_attack` | `arp_cache_poisoning` | arp_cache_poisoning | 28 |
+| `network_under_attack` | `bgp_hijacking` | bgp_hijacking | 9 |
+| `network_under_attack` | `dhcp_spoofed_dns` | Some hosts can not access webservices. | 3 |
+| `network_under_attack` | `dhcp_spoofed_gateway` | dhcp_spoofed_gateway | 3 |
+| `network_under_attack` | `dhcp_spoofed_subnet` | dhcp_spoofed_subnet | 3 |
+| `network_under_attack` | `web_dos_attack` | Users reports high latency when accessing some web services. | 13 |
+| `resource_contention` | `dns_lookup_latency` | Users experience high latency when accessing web services. | 6 |
+| `resource_contention` | `incast_traffic_network_limitation` | incast_traffic_network_limitation | 13 |
+| `resource_contention` | `link_bandwidth_throttling` | link_bandwidth_throttling | 29 |
+| `resource_contention` | `link_high_packet_corruption` | link_high_packet_corruption | 29 |
+| `resource_contention` | `load_balancer_overload` | load_balancer_overload | 3 |
+| `resource_contention` | `receiver_resource_contention` | receiver_resource_contention | 13 |
+| `resource_contention` | `sender_application_delay` | sender_application_delay | 13 |
+| `resource_contention` | `sender_resource_contention` | sender_resource_contention | 13 |
+| **Total** | - | - | **702** |
+
+See [Creating benchmark tasks](creating-benchmark-tasks.md) to add a new failure type, and `nika failure describe <problem_id>` for the required inject parameters of any entry above.


### PR DESCRIPTION
## Summary
- Restore the Features section that was dropped when the README was shortened in `4a791b4`, updated to reflect current docs (agent sandboxing, NIKA Remote, leaderboard, agent skills).
- Rework Installation into Requirements/Setup/API keys/Remote Deployments subsections with bold backend choices (Kathará / Containerlab / both) instead of a full comparison table.
- Wrap the collapsible failure-types table in a GitHub `[!TIP]` callout so the expand hint and the table render as one box.

## Test plan
- [ ] Preview README.md rendering on GitHub to confirm the TIP callout, Features list, and Installation subsections render as expected.