### PR TITLE
Fix #40: add reasoning_effort for BYO agents

### DIFF
--- a/config/nika.example.yaml
+++ b/config/nika.example.yaml
@@ -37,6 +37,9 @@ agent:
   provider: openai
   model: null
   max_steps: 20
+  # none | minimal | low | medium | high | xhigh
+  # byo.langgraph / byo.autogen / cli.codex / sdk.codex_sdk
+  # byo.mcp_agent: none | low | medium | high only
   reasoning_effort: null
   models:
     langgraph: gpt-5-mini

--- a/docs/agent-implementations.md
+++ b/docs/agent-implementations.md
@@ -124,12 +124,17 @@ LangGraph orchestration + LangChain ReAct workers per phase.
 | `deepseek` | `DEEPSEEK_API_KEY` in `.env` |
 | `custom` | `agent.custom.base_url` (+ optional model) in YAML; `NIKA_CUSTOM_API_KEY` in `.env` if needed |
 
+| Flag | YAML | Notes |
+|------|------|-------|
+| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; optional. Passed to OpenAI, Anthropic, and custom LangChain clients (ignored for DeepSeek). Required by some GPT-5.x models. |
+
 ```yaml
 # config/nika.yaml
 agent:
   type: byo.langgraph
   provider: openai
   max_steps: 20
+  reasoning_effort: medium
   models:
     langgraph: gpt-5-mini
 ```
@@ -138,6 +143,7 @@ agent:
 nika agent run                              # from config/nika.yaml + .env
 nika agent run -a byo.langgraph -p deepseek -m deepseek-chat -n 20
 nika agent run -a byo.langgraph -p anthropic -m claude-haiku-4-5 -n 20
+nika agent run -a byo.langgraph -p openai -m gpt-5-mini -e medium -n 20
 ```
 
 ### Local / OpenAI-compatible endpoints (`custom`)
@@ -248,17 +254,22 @@ mcp-agent ``Workflow`` orchestration + [mcp-agent SDK](https://docs.mcp-agent.co
 | `deepseek` | `DEEPSEEK_API_KEY` in `.env` |
 | `custom` | `agent.custom.base_url` (+ optional model) in YAML; `NIKA_CUSTOM_API_KEY` in `.env` if needed |
 
+| Flag | YAML | Notes |
+|------|------|-------|
+| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `low`, `medium`, `high` (mcp-agent does not accept `minimal` / `xhigh`). OpenAI/custom only; ignored for DeepSeek and Anthropic. |
+
 ```yaml
 agent:
   type: byo.mcp_agent
   provider: openai
   max_steps: 20
+  reasoning_effort: medium
   models:
-    mcp_agent: gpt-4.1-mini
+    mcp_agent: gpt-5-mini
 ```
 
 ```bash
-nika agent run -a byo.mcp_agent -m gpt-4.1-mini -n 20
+nika agent run -a byo.mcp_agent -m gpt-5-mini -e medium -n 20
 nika agent run -a byo.mcp_agent -p anthropic -m claude-haiku-4-5 -n 20
 ```
 
@@ -279,17 +290,22 @@ AutoGen ``GraphFlow`` orchestration + [AutoGen AgentChat](https://microsoft.gith
 | `deepseek` | `DEEPSEEK_API_KEY` in `.env` |
 | `custom` | `agent.custom.base_url` (+ optional model) in YAML; `NIKA_CUSTOM_API_KEY` in `.env` if needed |
 
+| Flag | YAML | Notes |
+|------|------|-------|
+| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; optional. Passed to OpenAI/custom AutoGen clients (ignored for DeepSeek and Anthropic). |
+
 ```yaml
 agent:
   type: byo.autogen
   provider: openai
   max_steps: 20
+  reasoning_effort: medium
   models:
-    autogen: gpt-4.1-mini
+    autogen: gpt-5-mini
 ```
 
 ```bash
-nika agent run -a byo.autogen -m gpt-4.1-mini -n 20
+nika agent run -a byo.autogen -m gpt-5-mini -e medium -n 20
 nika agent run -a byo.autogen -p anthropic -m claude-haiku-4-5 -n 20
 ```
 

--- a/docs/agent-implementations.md
+++ b/docs/agent-implementations.md
@@ -256,7 +256,7 @@ mcp-agent ``Workflow`` orchestration + [mcp-agent SDK](https://docs.mcp-agent.co
 
 | Flag | YAML | Notes |
 |------|------|-------|
-| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `low`, `medium`, `high` (mcp-agent does not accept `minimal` / `xhigh`). OpenAI/custom only; ignored for DeepSeek and Anthropic. |
+| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `low`, `medium`, `high` (mcp-agent does not accept `minimal` / `xhigh`). OpenAI/custom via `reasoning_effort`; Anthropic via `output_config.effort` (`none` omitted). Ignored for DeepSeek. |
 
 ```yaml
 agent:
@@ -270,7 +270,7 @@ agent:
 
 ```bash
 nika agent run -a byo.mcp_agent -m gpt-5-mini -e medium -n 20
-nika agent run -a byo.mcp_agent -p anthropic -m claude-haiku-4-5 -n 20
+nika agent run -a byo.mcp_agent -p anthropic -m claude-haiku-4-5 -e low -n 20
 ```
 
 ---
@@ -292,7 +292,7 @@ AutoGen ``GraphFlow`` orchestration + [AutoGen AgentChat](https://microsoft.gith
 
 | Flag | YAML | Notes |
 |------|------|-------|
-| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; optional. Passed to OpenAI/custom AutoGen clients (ignored for DeepSeek and Anthropic). |
+| `-e` / `--reasoning-effort` | `agent.reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; optional. OpenAI/custom via client `reasoning_effort`; Anthropic via `output_config.effort` (`minimal`→`low`, `none` omitted). Ignored for DeepSeek. |
 
 ```yaml
 agent:
@@ -306,7 +306,7 @@ agent:
 
 ```bash
 nika agent run -a byo.autogen -m gpt-5-mini -e medium -n 20
-nika agent run -a byo.autogen -p anthropic -m claude-haiku-4-5 -n 20
+nika agent run -a byo.autogen -p anthropic -m claude-haiku-4-5 -e low -n 20
 ```
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,7 +77,7 @@ Aligned with `nika agent run`:
 - **`-p` / `--provider`**: LLM provider for all agents (`openai`, `anthropic`, `deepseek`, `custom`; capabilities differ by agent).
 - **`-m` / `--model`**: model id.
 - **`-n` / `--max-steps`**: max steps per phase (`byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `community.sade`, `sdk.claude_sdk`).
-- **`-e` / `--reasoning-effort`**: Codex `model_reasoning_effort` (`cli.codex`, `sdk.codex_sdk`): `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- **`-e` / `--reasoning-effort`**: Reasoning effort for BYO agents (`byo.langgraph`, `byo.mcp_agent`, `byo.autogen`), `cli.codex`, and `sdk.codex_sdk`: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. `byo.mcp_agent` accepts `none` / `low` / `medium` / `high` only.
 
 `nika eval judge` uses **`-p`** and **`-m`** for the judge only (no agent in that command).
 
@@ -128,7 +128,7 @@ Example: `nika exec pc1 ping -c 3 10.0.0.2 --timeout 30`
 
 ## `nika agent`
 
-- **`nika agent list`**: supported agent types (`byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `cli.codex`, `cli.claude`, `community.sade`, `sdk.claude_sdk`, `sdk.codex_sdk`), LLM providers, and Codex reasoning-effort levels.
+- **`nika agent list`**: supported agent types (`byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `cli.codex`, `cli.claude`, `community.sade`, `sdk.claude_sdk`, `sdk.codex_sdk`), LLM providers, and reasoning-effort levels.
 - **`nika agent run`**: two modes:
 
   1. **Task mode (recommended):** `--problem LABEL` runs the complete task lifecycle: deploy the lab, inject the fault (using defaults from the benchmark resolver), run the agent, close the session, and write metrics.
@@ -149,7 +149,7 @@ Example: `nika exec pc1 ping -c 3 10.0.0.2 --timeout 30`
   | `-p` / `--provider` | both | Shared: `openai`, `anthropic`, `deepseek`, or `custom` |
   | `-m` / `--model` | both | model id |
   | `-n` / `--max-steps` | both | step cap per phase (`byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `community.sade`, `sdk.claude_sdk`) |
-  | `-e` / `--reasoning-effort` | both | Codex reasoning effort level |
+  | `-e` / `--reasoning-effort` | both | Reasoning effort (BYO agents, `cli.codex`, `sdk.codex_sdk`) |
   | `--problem` | task | task label (see above) |
   | `--set key=value` | task | override inject parameters (repeatable) |
   | `--result_dir` | task | results parent directory |
@@ -295,7 +295,7 @@ nika benchmark run --release 0.1.0 --batch-size 4 --retry-passes 2 --result_dir 
 | `inject` | Map of `--set key=value` pairs passed to `nika failure inject` |
 | `root_causes` | Materialized diagnoses (`resource` + `fault_type`); `resource_id` is derived on submit and scoring; see [root-cause ground truth and scoring](root-cause-evaluation.md) |
 
-Benchmark exposes `-a`, `-p`, `-m`, and `-n`; `-n` affects `byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `community.sade`, and `sdk.claude_sdk`. It does not expose `-e`; configure Codex reasoning through `agent.reasoning_effort` in `config/nika.yaml` for benchmark runs.
+Benchmark exposes `-a`, `-p`, `-m`, and `-n`; `-n` affects `byo.langgraph`, `byo.mcp_agent`, `byo.autogen`, `community.sade`, and `sdk.claude_sdk`. It does not expose `-e`; configure reasoning through `agent.reasoning_effort` in `config/nika.yaml` for benchmark runs.
 
 ### Single-case mode
 

--- a/src/agent/byo/autogen/agent.py
+++ b/src/agent/byo/autogen/agent.py
@@ -25,11 +25,13 @@ class AutogenAgent:
         model: str = "gpt-4.1-mini",
         max_steps: int = 20,
         *,
+        reasoning_effort: str | None = None,
         stream_output: bool = True,
     ) -> None:
         self.session_id = session_id
         self.model = model
         self.max_steps = max_steps
+        self.reasoning_effort = reasoning_effort
         self._stream_output = stream_output
 
         session = Session()
@@ -47,5 +49,6 @@ class AutogenAgent:
             model=self.model,
             max_steps=self.max_steps,
             scenario_name=self._scenario_name,
+            reasoning_effort=self.reasoning_effort,
             stream_output=self._stream_output,
         )

--- a/src/agent/byo/autogen/phases/diagnosis.py
+++ b/src/agent/byo/autogen/phases/diagnosis.py
@@ -43,17 +43,22 @@ class AutogenDiagnosisPhase:
         model: str,
         max_steps: int,
         scenario_name: str,
+        *,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._session_id = session_id
         self._session_dir = session_dir
         self._model = model
         self._max_steps = max_steps
+        self._reasoning_effort = reasoning_effort
         self._server_configs = session_server_configs(session_id, scenario_name)
 
     async def run(self, task_description: str) -> tuple[str, bool]:
         """Return ``(diagnosis_report, is_max_steps_reached)``."""
         logger = MessageLogger(agent=DIAGNOSIS, session_dir=self._session_dir)
-        model_client = create_model_client(self._model)
+        model_client = create_model_client(
+            self._model, reasoning_effort=self._reasoning_effort
+        )
 
         async with _open_mcp_tools(self._server_configs) as tools:
             agent = AssistantAgent(

--- a/src/agent/byo/autogen/phases/submission.py
+++ b/src/agent/byo/autogen/phases/submission.py
@@ -44,12 +44,15 @@ class AutogenSubmissionPhase:
         model: str,
         max_steps: int,
         scenario_name: str,
+        *,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._session_id = session_id
         self._session_dir = session_dir
         self._model = model
         self._max_steps = max_steps
         self._scenario_name = scenario_name
+        self._reasoning_effort = reasoning_effort
 
     async def run(self, diagnosis_report: str) -> str:
         begin_submission_mcp_phase(self._session_id)
@@ -58,7 +61,9 @@ class AutogenSubmissionPhase:
             self._scenario_name,
         )
         logger = MessageLogger(agent=SUBMISSION, session_dir=self._session_dir)
-        model_client = create_model_client(self._model)
+        model_client = create_model_client(
+            self._model, reasoning_effort=self._reasoning_effort
+        )
         prompt = (
             f"Based on the diagnosis report: {diagnosis_report}, "
             "please provide the submission. Do not submit if no report available."

--- a/src/agent/byo/autogen/runner.py
+++ b/src/agent/byo/autogen/runner.py
@@ -24,6 +24,8 @@ from agent.utils.provider_env import (
     resolve_custom_api_key,
     resolve_custom_base_url,
 )
+from agent.utils.reasoning_effort import map_anthropic_effort
+
 
 _KATHARA_PREFIXES = MCP_SERVER_PREFIXES
 
@@ -72,6 +74,37 @@ def _resolve_provider(provider: str | None = None) -> str:
     return ""
 
 
+def _inject_anthropic_output_config(
+    client: AnthropicChatCompletionClient, reasoning_effort: str | None
+) -> AnthropicChatCompletionClient:
+    """Wrap the underlying Anthropic SDK so create/stream send output_config.effort.
+
+    Autogen's AnthropicChatCompletionClient does not forward ``output_config``;
+    inject it on the low-level Messages API instead.
+    """
+    effort = map_anthropic_effort(reasoning_effort)
+    if effort is None:
+        return client
+    messages_api = client._client.messages
+    orig_create = messages_api.create
+    orig_stream = messages_api.stream
+
+    def _with_effort(kwargs: dict) -> dict:
+        out = dict(kwargs)
+        out.setdefault("output_config", {"effort": effort})
+        return out
+
+    def create(*args, **kwargs):
+        return orig_create(*args, **_with_effort(kwargs))
+
+    def stream(*args, **kwargs):
+        return orig_stream(*args, **_with_effort(kwargs))
+
+    messages_api.create = create  # type: ignore[method-assign]
+    messages_api.stream = stream  # type: ignore[method-assign]
+    return client
+
+
 def create_model_client(
     model: str,
     *,
@@ -99,7 +132,8 @@ def create_model_client(
         base = os.environ.get(ENV_ANTHROPIC_BASE_URL, "").strip()
         if base:
             kwargs["base_url"] = base
-        return AnthropicChatCompletionClient(**kwargs)
+        client = AnthropicChatCompletionClient(**kwargs)
+        return _inject_anthropic_output_config(client, reasoning_effort)
 
     if prov == "deepseek":
         api_key = os.environ.get(ENV_DEEPSEEK_API_KEY) or os.environ.get(

--- a/src/agent/byo/autogen/runner.py
+++ b/src/agent/byo/autogen/runner.py
@@ -73,7 +73,10 @@ def _resolve_provider(provider: str | None = None) -> str:
 
 
 def create_model_client(
-    model: str, *, provider: str | None = None
+    model: str,
+    *,
+    provider: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> ChatCompletionClient:
     """Build an AutoGen chat client for the active provider."""
     prov = _resolve_provider(provider)
@@ -124,12 +127,15 @@ def create_model_client(
         api_key = (
             resolve_custom_api_key() or os.environ.get(ENV_OPENAI_API_KEY) or "no-key"
         )
-        return OpenAIChatCompletionClient(
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
-            model_info=_OPENAI_COMPAT_MODEL_INFO,
-        )
+        kwargs = {
+            "model": model,
+            "base_url": base_url,
+            "api_key": api_key,
+            "model_info": _OPENAI_COMPAT_MODEL_INFO,
+        }
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+        return OpenAIChatCompletionClient(**kwargs)
 
     # openai (default): rely on OPENAI_API_KEY / OPENAI_BASE_URL from env
     kwargs = {"model": model}
@@ -140,6 +146,8 @@ def create_model_client(
         kwargs["model_info"] = _OPENAI_COMPAT_MODEL_INFO
     if key:
         kwargs["api_key"] = key
+    if reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
     return OpenAIChatCompletionClient(**kwargs)
 
 

--- a/src/agent/byo/autogen/workflow.py
+++ b/src/agent/byo/autogen/workflow.py
@@ -31,6 +31,7 @@ class DiagnosisPhaseAgent(BaseChatAgent):
         model: str,
         max_steps: int,
         scenario_name: str,
+        reasoning_effort: str | None = None,
         print_phase: Callable[[str, str], None],
     ) -> None:
         super().__init__(
@@ -43,6 +44,7 @@ class DiagnosisPhaseAgent(BaseChatAgent):
             model=model,
             max_steps=max_steps,
             scenario_name=scenario_name,
+            reasoning_effort=reasoning_effort,
         )
         self._session_dir = session_dir
         self._print_phase = print_phase
@@ -121,6 +123,7 @@ class SubmissionPhaseAgent(BaseChatAgent):
         model: str,
         max_steps: int,
         scenario_name: str,
+        reasoning_effort: str | None = None,
         print_phase: Callable[[str, str], None],
     ) -> None:
         super().__init__(
@@ -133,6 +136,7 @@ class SubmissionPhaseAgent(BaseChatAgent):
             model=model,
             max_steps=max_steps,
             scenario_name=scenario_name,
+            reasoning_effort=reasoning_effort,
         )
         self._session_dir = session_dir
         self._print_phase = print_phase
@@ -185,6 +189,7 @@ async def run_troubleshooting_flow(
     max_steps: int,
     scenario_name: str,
     stream_output: bool,
+    reasoning_effort: str | None = None,
 ) -> dict[str, Any]:
     """Execute diagnosis → submission via AutoGen ``GraphFlow``."""
     print_phase = _make_print_phase(stream_output)
@@ -195,6 +200,7 @@ async def run_troubleshooting_flow(
         model=model,
         max_steps=max_steps,
         scenario_name=scenario_name,
+        reasoning_effort=reasoning_effort,
         print_phase=print_phase,
     )
     submission_agent = SubmissionPhaseAgent(
@@ -203,6 +209,7 @@ async def run_troubleshooting_flow(
         model=model,
         max_steps=max_steps,
         scenario_name=scenario_name,
+        reasoning_effort=reasoning_effort,
         print_phase=print_phase,
     )
 

--- a/src/agent/byo/langgraph/phases/diagnosis.py
+++ b/src/agent/byo/langgraph/phases/diagnosis.py
@@ -21,6 +21,7 @@ class DiagnosisPhase:
         llm_provider: str = "openai",
         model: str = "gpt-5-mini",
         scenario_name: str = "",
+        reasoning_effort: str | None = None,
     ):
         mcp_server_config = load_session_mcp_config(
             session_id,
@@ -28,7 +29,11 @@ class DiagnosisPhase:
         )
         self.client = MultiServerMCPClient(connections=mcp_server_config)
         self.tools = None
-        self.llm = load_model(llm_provider=llm_provider, model=model)
+        self.llm = load_model(
+            llm_provider=llm_provider,
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
 
     async def load_tools(self):
         self.tools: list[StructuredTool] = await self.client.get_tools()

--- a/src/agent/byo/langgraph/phases/submission.py
+++ b/src/agent/byo/langgraph/phases/submission.py
@@ -22,6 +22,7 @@ class SubmissionPhase:
         llm_provider: str = "openai",
         model: str = "gpt-5-mini",
         scenario_name: str = "",
+        reasoning_effort: str | None = None,
     ):
         session = Session()
         session.load_running_session(session_id=session_id)
@@ -32,7 +33,11 @@ class SubmissionPhase:
         self.client = MultiServerMCPClient(connections=mcp_server_config)
         self.tools = None
 
-        self.llm = load_model(llm_provider=llm_provider, model=model)
+        self.llm = load_model(
+            llm_provider=llm_provider,
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
 
     async def load_tools(self):
         self.tools: list[StructuredTool] = await self.client.get_tools()

--- a/src/agent/byo/langgraph/react_agent.py
+++ b/src/agent/byo/langgraph/react_agent.py
@@ -50,11 +50,13 @@ class BasicReActAgent:
         llm_provider: str = "openai",
         model: str = "gpt-5-mini",
         max_steps: int = 20,
+        reasoning_effort: str | None = None,
     ):
         self.session_id = session_id
         self.max_steps = max_steps
         self.llm_provider = llm_provider
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.session = Session()
         self.session.load_running_session(session_id=session_id)
         self.session_dir = self.session.session_dir
@@ -66,6 +68,7 @@ class BasicReActAgent:
             llm_provider=llm_provider,
             model=model,
             scenario_name=self.session.scenario_name,
+            reasoning_effort=reasoning_effort,
         )
         asyncio.run(diagnosis_phase.load_tools())
         self._diagnosis_runner = diagnosis_phase.get_agent()
@@ -184,6 +187,7 @@ class BasicReActAgent:
             llm_provider=self.llm_provider,
             model=self.model,
             scenario_name=self.session.scenario_name,
+            reasoning_effort=self.reasoning_effort,
         )
         await submission_phase.load_tools()
         submission_runner = submission_phase.get_agent()

--- a/src/agent/byo/mcp_agent/agent.py
+++ b/src/agent/byo/mcp_agent/agent.py
@@ -28,11 +28,13 @@ class McpAgent:
         model: str = "gpt-4.1-mini",
         max_steps: int = 20,
         *,
+        reasoning_effort: str | None = None,
         stream_output: bool = True,
     ) -> None:
         self.session_id = session_id
         self.model = model
         self.max_steps = max_steps
+        self.reasoning_effort = reasoning_effort
         self._stream_output = stream_output
 
         session = Session()
@@ -48,6 +50,7 @@ class McpAgent:
             session_id=self.session_id,
             scenario_name=self._scenario_name,
             model=self.model,
+            reasoning_effort=self.reasoning_effort,
         )
         app = MCPApp(
             name="nika_mcp_agent", settings=settings, session_id=self.session_id
@@ -60,6 +63,7 @@ class McpAgent:
                 model=self.model,
                 max_steps=self.max_steps,
                 scenario_name=self._scenario_name,
+                reasoning_effort=self.reasoning_effort,
                 stream_output=self._stream_output,
             )
             await workflow.initialize()

--- a/src/agent/byo/mcp_agent/config.py
+++ b/src/agent/byo/mcp_agent/config.py
@@ -48,12 +48,35 @@ def _to_server_settings(server: dict) -> MCPServerSettings:
     )
 
 
+# mcp-agent OpenAISettings / RequestParams accept these only (not minimal/xhigh).
+_MCP_REASONING_EFFORT_LEVELS = ("none", "low", "medium", "high")
+
+
+def _mcp_reasoning_effort(reasoning_effort: str | None) -> str | None:
+    if reasoning_effort is None:
+        return None
+    if reasoning_effort not in _MCP_REASONING_EFFORT_LEVELS:
+        raise ValueError(
+            "byo.mcp_agent reasoning_effort must be one of "
+            f"{', '.join(_MCP_REASONING_EFFORT_LEVELS)}, got {reasoning_effort!r}"
+        )
+    return reasoning_effort
+
+
 def _resolve_provider(provider: str | None) -> str:
     return (provider or os.environ.get("NIKA_LLM_PROVIDER") or "openai").strip().lower()
 
 
-def _openai_settings_for_provider(model: str, provider: str | None) -> OpenAISettings:
+def _openai_settings_for_provider(
+    model: str,
+    provider: str | None,
+    *,
+    reasoning_effort: str | None = None,
+) -> OpenAISettings:
     prov = _resolve_provider(provider)
+    effort = _mcp_reasoning_effort(reasoning_effort)
+    # DeepSeek OpenAI-compat does not take reasoning_effort.
+    apply_effort = effort is not None and prov != "deepseek"
     if prov == "deepseek":
         api_key = os.environ.get(ENV_DEEPSEEK_API_KEY) or os.environ.get(
             ENV_OPENAI_API_KEY
@@ -66,16 +89,22 @@ def _openai_settings_for_provider(model: str, provider: str | None) -> OpenAISet
     if prov == "custom":
         base = resolve_custom_base_url() or os.environ.get(ENV_OPENAI_BASE_URL) or None
         key = resolve_custom_api_key() or os.environ.get(ENV_OPENAI_API_KEY) or None
-        return OpenAISettings(
-            default_model=model,
-            api_key=key,
-            base_url=base,
-        )
-    return OpenAISettings(
-        default_model=model,
-        api_key=os.environ.get(ENV_OPENAI_API_KEY) or None,
-        base_url=os.environ.get(ENV_OPENAI_BASE_URL) or None,
-    )
+        kwargs: dict = {
+            "default_model": model,
+            "api_key": key,
+            "base_url": base,
+        }
+        if apply_effort:
+            kwargs["reasoning_effort"] = effort
+        return OpenAISettings(**kwargs)
+    kwargs = {
+        "default_model": model,
+        "api_key": os.environ.get(ENV_OPENAI_API_KEY) or None,
+        "base_url": os.environ.get(ENV_OPENAI_BASE_URL) or None,
+    }
+    if apply_effort:
+        kwargs["reasoning_effort"] = effort
+    return OpenAISettings(**kwargs)
 
 
 def _anthropic_settings_for_provider(model: str) -> AnthropicSettings:
@@ -93,6 +122,7 @@ def build_mcp_agent_settings(
     model: str,
     *,
     provider: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> Settings:
     """Build mcp-agent Settings for a NIKA troubleshooting session."""
     servers = load_session_mcp_config(session_id, scenario_name)
@@ -110,7 +140,9 @@ def build_mcp_agent_settings(
         )
     return Settings(
         **common,
-        openai=_openai_settings_for_provider(model, provider),
+        openai=_openai_settings_for_provider(
+            model, provider, reasoning_effort=reasoning_effort
+        ),
     )
 
 

--- a/src/agent/byo/mcp_agent/config.py
+++ b/src/agent/byo/mcp_agent/config.py
@@ -24,6 +24,7 @@ from agent.utils.provider_env import (
     resolve_custom_api_key,
     resolve_custom_base_url,
 )
+from agent.utils.reasoning_effort import anthropic_output_config
 
 
 def _to_server_settings(server: dict) -> MCPServerSettings:
@@ -114,6 +115,39 @@ def _anthropic_settings_for_provider(model: str) -> AnthropicSettings:
         api_key=os.environ.get(ENV_ANTHROPIC_API_KEY) or None,
         base_url=os.environ.get(ENV_ANTHROPIC_BASE_URL) or None,
     )
+
+
+def build_mcp_request_params(
+    *,
+    model: str,
+    max_steps: int,
+    reasoning_effort: str | None = None,
+    provider: str | None = None,
+):
+    """Build mcp-agent ``RequestParams`` with provider-appropriate effort wiring.
+
+    OpenAI/custom: ``reasoning_effort`` field.
+    Anthropic: ``metadata.output_config.effort`` (merged into messages.create).
+    DeepSeek: omit.
+    """
+    from mcp_agent.workflows.llm.augmented_llm import RequestParams
+
+    effort = _mcp_reasoning_effort(reasoning_effort)
+    kwargs: dict = {
+        "model": model,
+        "max_iterations": max_steps,
+        "temperature": 0,
+        "use_history": False,
+    }
+    prov = _resolve_provider(provider)
+    if effort is not None and prov == "anthropic":
+        # Anthropic rejects "none"; omit output_config in that case.
+        meta = anthropic_output_config(effort)
+        if meta is not None:
+            kwargs["metadata"] = meta
+    elif effort is not None and prov != "deepseek":
+        kwargs["reasoning_effort"] = effort
+    return RequestParams(**kwargs)
 
 
 def build_mcp_agent_settings(

--- a/src/agent/byo/mcp_agent/phases/diagnosis.py
+++ b/src/agent/byo/mcp_agent/phases/diagnosis.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from mcp_agent.agents.agent import Agent
-from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
-from agent.byo.mcp_agent.config import _mcp_reasoning_effort
+from agent.byo.mcp_agent.config import _mcp_reasoning_effort, build_mcp_request_params
 from agent.byo.mcp_agent.llm import create_nika_augmented_llm
 from agent.utils.loggers import MessageLogger
 from agent.protocols import DIAGNOSIS
@@ -33,15 +32,11 @@ class McpDiagnosisPhase:
     async def run(self, task_description: str) -> tuple[str, bool]:
         """Return ``(diagnosis_report, is_max_steps_reached)``."""
         logger = MessageLogger(agent=DIAGNOSIS, session_dir=self._session_dir)
-        request_kwargs: dict = {
-            "model": self._model,
-            "max_iterations": self._max_steps,
-            "temperature": 0,
-            "use_history": False,
-        }
-        if self._reasoning_effort is not None:
-            request_kwargs["reasoning_effort"] = self._reasoning_effort
-        request_params = RequestParams(**request_kwargs)
+        request_params = build_mcp_request_params(
+            model=self._model,
+            max_steps=self._max_steps,
+            reasoning_effort=self._reasoning_effort,
+        )
 
         agent = Agent(
             name=DIAGNOSIS,

--- a/src/agent/byo/mcp_agent/phases/diagnosis.py
+++ b/src/agent/byo/mcp_agent/phases/diagnosis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
+from agent.byo.mcp_agent.config import _mcp_reasoning_effort
 from agent.byo.mcp_agent.llm import create_nika_augmented_llm
 from agent.utils.loggers import MessageLogger
 from agent.protocols import DIAGNOSIS
@@ -20,21 +21,27 @@ class McpDiagnosisPhase:
         model: str,
         max_steps: int,
         server_names: list[str],
+        *,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._session_dir = session_dir
         self._model = model
         self._max_steps = max_steps
         self._server_names = server_names
+        self._reasoning_effort = _mcp_reasoning_effort(reasoning_effort)
 
     async def run(self, task_description: str) -> tuple[str, bool]:
         """Return ``(diagnosis_report, is_max_steps_reached)``."""
         logger = MessageLogger(agent=DIAGNOSIS, session_dir=self._session_dir)
-        request_params = RequestParams(
-            model=self._model,
-            max_iterations=self._max_steps,
-            temperature=0,
-            use_history=False,
-        )
+        request_kwargs: dict = {
+            "model": self._model,
+            "max_iterations": self._max_steps,
+            "temperature": 0,
+            "use_history": False,
+        }
+        if self._reasoning_effort is not None:
+            request_kwargs["reasoning_effort"] = self._reasoning_effort
+        request_params = RequestParams(**request_kwargs)
 
         agent = Agent(
             name=DIAGNOSIS,

--- a/src/agent/byo/mcp_agent/phases/submission.py
+++ b/src/agent/byo/mcp_agent/phases/submission.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from mcp_agent.agents.agent import Agent
-from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
-from agent.byo.mcp_agent.config import _mcp_reasoning_effort
+from agent.byo.mcp_agent.config import _mcp_reasoning_effort, build_mcp_request_params
 from agent.byo.mcp_agent.llm import create_nika_augmented_llm
 from agent.utils.loggers import MessageLogger
 from agent.utils.mcp_client import begin_submission_mcp_phase
@@ -36,15 +35,11 @@ class McpSubmissionPhase:
     async def run(self, diagnosis_report: str) -> str:
         begin_submission_mcp_phase(self._session_id)
         logger = MessageLogger(agent=SUBMISSION, session_dir=self._session_dir)
-        request_kwargs: dict = {
-            "model": self._model,
-            "max_iterations": self._max_steps,
-            "temperature": 0,
-            "use_history": False,
-        }
-        if self._reasoning_effort is not None:
-            request_kwargs["reasoning_effort"] = self._reasoning_effort
-        request_params = RequestParams(**request_kwargs)
+        request_params = build_mcp_request_params(
+            model=self._model,
+            max_steps=self._max_steps,
+            reasoning_effort=self._reasoning_effort,
+        )
         prompt = (
             f"{SUBMIT_PROMPT_TEMPLATE}\n\n"
             f"Based on the diagnosis report: {diagnosis_report}\n"

--- a/src/agent/byo/mcp_agent/phases/submission.py
+++ b/src/agent/byo/mcp_agent/phases/submission.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
+from agent.byo.mcp_agent.config import _mcp_reasoning_effort
 from agent.byo.mcp_agent.llm import create_nika_augmented_llm
 from agent.utils.loggers import MessageLogger
 from agent.utils.mcp_client import begin_submission_mcp_phase
@@ -22,22 +23,28 @@ class McpSubmissionPhase:
         model: str,
         max_steps: int,
         server_names: list[str],
+        *,
+        reasoning_effort: str | None = None,
     ) -> None:
         self._session_id = session_id
         self._session_dir = session_dir
         self._model = model
         self._max_steps = max_steps
         self._server_names = server_names
+        self._reasoning_effort = _mcp_reasoning_effort(reasoning_effort)
 
     async def run(self, diagnosis_report: str) -> str:
         begin_submission_mcp_phase(self._session_id)
         logger = MessageLogger(agent=SUBMISSION, session_dir=self._session_dir)
-        request_params = RequestParams(
-            model=self._model,
-            max_iterations=self._max_steps,
-            temperature=0,
-            use_history=False,
-        )
+        request_kwargs: dict = {
+            "model": self._model,
+            "max_iterations": self._max_steps,
+            "temperature": 0,
+            "use_history": False,
+        }
+        if self._reasoning_effort is not None:
+            request_kwargs["reasoning_effort"] = self._reasoning_effort
+        request_params = RequestParams(**request_kwargs)
         prompt = (
             f"{SUBMIT_PROMPT_TEMPLATE}\n\n"
             f"Based on the diagnosis report: {diagnosis_report}\n"

--- a/src/agent/byo/mcp_agent/workflow.py
+++ b/src/agent/byo/mcp_agent/workflow.py
@@ -25,6 +25,7 @@ class NikaTroubleshootingWorkflow(Workflow[dict[str, Any]]):
         model: str,
         max_steps: int,
         scenario_name: str,
+        reasoning_effort: str | None = None,
         stream_output: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -34,6 +35,7 @@ class NikaTroubleshootingWorkflow(Workflow[dict[str, Any]]):
         self._model = model
         self._max_steps = max_steps
         self._scenario_name = scenario_name
+        self._reasoning_effort = reasoning_effort
         self._stream_output = stream_output
         self._server_names = session_server_names(scenario_name)
 
@@ -70,6 +72,7 @@ class NikaTroubleshootingWorkflow(Workflow[dict[str, Any]]):
             model=self._model,
             max_steps=self._max_steps,
             server_names=self._server_names,
+            reasoning_effort=self._reasoning_effort,
         )
         try:
             report, is_max_steps_reached = await phase.run(task_description)
@@ -110,6 +113,7 @@ class NikaTroubleshootingWorkflow(Workflow[dict[str, Any]]):
             model=self._model,
             max_steps=self._max_steps,
             server_names=self._server_names,
+            reasoning_effort=self._reasoning_effort,
         )
         try:
             result = await phase.run(diagnosis_report)

--- a/src/agent/llm/model_factory.py
+++ b/src/agent/llm/model_factory.py
@@ -25,14 +25,20 @@ LLM_MAX_RETRIES = int(os.getenv("NIKA_LLM_RETRIES", "2"))
 
 
 def load_model(
-    llm_provider: str = "openai", model: str = "gpt-5-mini"
+    llm_provider: str = "openai",
+    model: str = "gpt-5-mini",
+    *,
+    reasoning_effort: str | None = None,
 ) -> BaseChatModel:
     if llm_provider == "openai":
-        return ChatOpenAI(
-            model_name=model,
-            timeout=LLM_TIMEOUT_SECONDS,
-            max_retries=LLM_MAX_RETRIES,
-        )
+        kwargs: dict = {
+            "model_name": model,
+            "timeout": LLM_TIMEOUT_SECONDS,
+            "max_retries": LLM_MAX_RETRIES,
+        }
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+        return ChatOpenAI(**kwargs)
 
     if llm_provider == "deepseek":
         return ChatDeepSeek(
@@ -55,24 +61,30 @@ def load_model(
         # LangChain OpenAI client requires a non-empty key string; unauthenticated
         # local endpoints can omit NIKA_CUSTOM_API_KEY — use a placeholder only
         # for the client constructor (not stored as a real credential).
-        return ChatOpenAI(
-            model=model,
-            base_url=base_url,
-            api_key=api_key or "no-key",
-            temperature=0,
-            timeout=LLM_TIMEOUT_SECONDS,
-            max_retries=LLM_MAX_RETRIES,
-        )
+        kwargs = {
+            "model": model,
+            "base_url": base_url,
+            "api_key": api_key or "no-key",
+            "temperature": 0,
+            "timeout": LLM_TIMEOUT_SECONDS,
+            "max_retries": LLM_MAX_RETRIES,
+        }
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+        return ChatOpenAI(**kwargs)
 
     if llm_provider == "anthropic":
         # Optional ANTHROPIC_BASE_URL supports Anthropic-compatible endpoints
         # (e.g. https://api.deepseek.com/anthropic).
-        return ChatAnthropic(
-            model=model,
-            api_key=os.getenv(ENV_ANTHROPIC_API_KEY) or None,
-            base_url=os.getenv(ENV_ANTHROPIC_BASE_URL) or None,
-            default_request_timeout=LLM_TIMEOUT_SECONDS,
-            max_retries=LLM_MAX_RETRIES,
-        )
+        kwargs = {
+            "model": model,
+            "api_key": os.getenv(ENV_ANTHROPIC_API_KEY) or None,
+            "base_url": os.getenv(ENV_ANTHROPIC_BASE_URL) or None,
+            "default_request_timeout": LLM_TIMEOUT_SECONDS,
+            "max_retries": LLM_MAX_RETRIES,
+        }
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+        return ChatAnthropic(**kwargs)
 
     raise ValueError(f"Unsupported llm provider: {llm_provider}")

--- a/src/agent/registry.py
+++ b/src/agent/registry.py
@@ -49,6 +49,7 @@ def create_agent(
                 llm_provider=llm_provider,
                 model=model,
                 max_steps=max_steps,
+                reasoning_effort=reasoning_effort,
             )
         case "mock":
             from agent.mock.mock_agent import MockAgent
@@ -100,6 +101,7 @@ def create_agent(
                 session_id=session_id,
                 model=model,
                 max_steps=max_steps,
+                reasoning_effort=reasoning_effort,
                 stream_output=stream_output,
             )
         case "byo.autogen":
@@ -109,6 +111,7 @@ def create_agent(
                 session_id=session_id,
                 model=model,
                 max_steps=max_steps,
+                reasoning_effort=reasoning_effort,
                 stream_output=stream_output,
             )
         case "community.sade":

--- a/src/agent/utils/reasoning_effort.py
+++ b/src/agent/utils/reasoning_effort.py
@@ -1,0 +1,34 @@
+"""Reasoning-effort helpers shared by BYO agents."""
+
+from __future__ import annotations
+
+# Anthropic Messages API output_config.effort values (no none/minimal).
+_ANTHROPIC_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
+
+
+def map_anthropic_effort(reasoning_effort: str | None) -> str | None:
+    """Map NIKA reasoning_effort to Anthropic ``output_config.effort``.
+
+    Returns ``None`` when effort should be omitted (unset or ``none``).
+    ``minimal`` maps to ``low``.
+    """
+    if reasoning_effort is None or reasoning_effort == "none":
+        return None
+    mapped = "low" if reasoning_effort == "minimal" else reasoning_effort
+    if mapped not in _ANTHROPIC_EFFORT_LEVELS:
+        raise ValueError(
+            "Anthropic reasoning_effort must map to one of "
+            f"{', '.join(sorted(_ANTHROPIC_EFFORT_LEVELS))} "
+            f"(got {reasoning_effort!r})"
+        )
+    return mapped
+
+
+def anthropic_output_config(
+    reasoning_effort: str | None,
+) -> dict[str, dict[str, str]] | None:
+    """Return ``{\"output_config\": {\"effort\": ...}}`` or ``None``."""
+    effort = map_anthropic_effort(reasoning_effort)
+    if effort is None:
+        return None
+    return {"output_config": {"effort": effort}}

--- a/src/nika/cli/commands/agent.py
+++ b/src/nika/cli/commands/agent.py
@@ -93,7 +93,10 @@ def agent_list() -> None:
     typer.echo("llm_providers:")
     for provider in SUPPORTED_LLM_PROVIDERS:
         typer.echo(f"  {provider}")
-    typer.echo("reasoning_effort (cli.codex, sdk.codex_sdk):")
+    typer.echo(
+        "reasoning_effort (byo.langgraph, byo.mcp_agent, byo.autogen, "
+        "cli.codex, sdk.codex_sdk):"
+    )
     for level in REASONING_EFFORT_LEVELS:
         typer.echo(f"  {level}")
 
@@ -128,7 +131,11 @@ def agent_run(
         None,
         "-e",
         "--reasoning-effort",
-        help="Codex model_reasoning_effort: none, minimal, low, medium, high, xhigh.",
+        help=(
+            "Reasoning effort for byo agents (openai/custom; anthropic on "
+            "langgraph), cli.codex, and sdk.codex_sdk: none, minimal, low, "
+            "medium, high, xhigh. byo.mcp_agent supports none/low/medium/high."
+        ),
     ),
     run_config: str | None = typer.Option(
         None,

--- a/tests/agent/test_model_factory.py
+++ b/tests/agent/test_model_factory.py
@@ -31,6 +31,7 @@ def test_load_model_anthropic_wires_chat_anthropic() -> None:
     assert kwargs["base_url"] == "https://api.deepseek.com/anthropic"
     assert "default_request_timeout" in kwargs
     assert "max_retries" in kwargs
+    assert "reasoning_effort" not in kwargs
 
 
 def test_load_model_anthropic_omits_empty_base_url() -> None:
@@ -46,6 +47,59 @@ def test_load_model_anthropic_omits_empty_base_url() -> None:
         load_model(llm_provider="anthropic", model="claude-haiku-4-5")
 
     assert ctor.call_args.kwargs["base_url"] is None
+
+
+def test_load_model_openai_passes_reasoning_effort() -> None:
+    fake = MagicMock(name="ChatOpenAI")
+    with patch("agent.llm.model_factory.ChatOpenAI", return_value=fake) as ctor:
+        model = load_model(
+            llm_provider="openai",
+            model="gpt-5.6",
+            reasoning_effort="medium",
+        )
+
+    assert model is fake
+    kwargs = ctor.call_args.kwargs
+    assert kwargs["model_name"] == "gpt-5.6"
+    assert kwargs["reasoning_effort"] == "medium"
+
+
+def test_load_model_openai_omits_reasoning_effort_when_unset() -> None:
+    fake = MagicMock(name="ChatOpenAI")
+    with patch("agent.llm.model_factory.ChatOpenAI", return_value=fake) as ctor:
+        load_model(llm_provider="openai", model="gpt-5-mini")
+
+    assert "reasoning_effort" not in ctor.call_args.kwargs
+
+
+def test_load_model_anthropic_passes_reasoning_effort() -> None:
+    fake = MagicMock(name="ChatAnthropic")
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant"}, clear=False),
+        patch("agent.llm.model_factory.ChatAnthropic", return_value=fake) as ctor,
+    ):
+        load_model(
+            llm_provider="anthropic",
+            model="claude-opus-4-6",
+            reasoning_effort="high",
+        )
+
+    assert ctor.call_args.kwargs["reasoning_effort"] == "high"
+
+
+def test_load_model_deepseek_ignores_reasoning_effort() -> None:
+    fake = MagicMock(name="ChatDeepSeek")
+    with (
+        patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-ds"}, clear=False),
+        patch("agent.llm.model_factory.ChatDeepSeek", return_value=fake) as ctor,
+    ):
+        load_model(
+            llm_provider="deepseek",
+            model="deepseek-chat",
+            reasoning_effort="medium",
+        )
+
+    assert "reasoning_effort" not in ctor.call_args.kwargs
 
 
 def test_load_model_rejects_unknown_provider() -> None:

--- a/tests/agent/test_openai_base_url.py
+++ b/tests/agent/test_openai_base_url.py
@@ -186,14 +186,56 @@ def test_autogen_deepseek_ignores_reasoning_effort(monkeypatch) -> None:
     assert "reasoning_effort" not in ctor.call_args.kwargs
 
 
-def test_autogen_anthropic_ignores_reasoning_effort(monkeypatch) -> None:
+def test_autogen_anthropic_injects_output_config(monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
     fake = MagicMock(name="client")
+    messages = MagicMock(name="messages")
+    fake._client.messages = messages
+    orig_create = MagicMock(name="orig_create")
+    orig_stream = MagicMock(name="orig_stream")
+    messages.create = orig_create
+    messages.stream = orig_stream
     with patch(
         "agent.byo.autogen.runner.AnthropicChatCompletionClient", return_value=fake
-    ) as ctor:
-        create_model_client(
-            "claude-haiku-4-5", provider="anthropic", reasoning_effort="medium"
+    ):
+        client = create_model_client(
+            "deepseek-v4-flash", provider="anthropic", reasoning_effort="low"
         )
 
-    assert "reasoning_effort" not in ctor.call_args.kwargs
+    assert client is fake
+    messages.create(model="deepseek-v4-flash", messages=[])
+    assert orig_create.call_args.kwargs["output_config"] == {"effort": "low"}
+
+
+def test_autogen_anthropic_omits_effort_for_none(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    fake = MagicMock(name="client")
+    messages = MagicMock(name="messages")
+    fake._client.messages = messages
+    orig_create = MagicMock(name="orig_create")
+    messages.create = orig_create
+    messages.stream = MagicMock(name="orig_stream")
+    with patch(
+        "agent.byo.autogen.runner.AnthropicChatCompletionClient", return_value=fake
+    ):
+        create_model_client(
+            "deepseek-v4-flash", provider="anthropic", reasoning_effort="none"
+        )
+
+    # none → no wrap; create remains the original mock.
+    messages.create(model="x", messages=[])
+    assert "output_config" not in orig_create.call_args.kwargs
+
+
+def test_mcp_agent_anthropic_request_params_use_output_config(monkeypatch) -> None:
+    from agent.byo.mcp_agent.config import build_mcp_request_params
+
+    monkeypatch.setenv("NIKA_LLM_PROVIDER", "anthropic")
+    params = build_mcp_request_params(
+        model="deepseek-v4-flash",
+        max_steps=10,
+        reasoning_effort="low",
+        provider="anthropic",
+    )
+    assert params.metadata == {"output_config": {"effort": "low"}}
+    assert params.reasoning_effort is None

--- a/tests/agent/test_openai_base_url.py
+++ b/tests/agent/test_openai_base_url.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent.byo.autogen.runner import create_model_client
 from agent.byo.mcp_agent.config import _openai_settings_for_provider
 
@@ -136,3 +138,62 @@ def test_mcp_agent_anthropic_settings(monkeypatch) -> None:
         "https://api.deepseek.com/anthropic"
     )
     assert settings.anthropic.default_model == "deepseek-v4-flash"
+
+
+def test_mcp_agent_openai_settings_passes_reasoning_effort(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    settings = _openai_settings_for_provider(
+        "gpt-5-mini", "openai", reasoning_effort="low"
+    )
+    assert settings.reasoning_effort == "low"
+
+
+def test_mcp_agent_rejects_unsupported_reasoning_effort() -> None:
+    with pytest.raises(ValueError, match="byo.mcp_agent reasoning_effort"):
+        _openai_settings_for_provider("gpt-5-mini", "openai", reasoning_effort="xhigh")
+
+
+def test_mcp_agent_deepseek_ignores_reasoning_effort(monkeypatch) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds")
+    settings = _openai_settings_for_provider(
+        "deepseek-chat", "deepseek", reasoning_effort="medium"
+    )
+    # OpenAISettings still has its library default; we simply omit the override.
+    assert settings.default_model == "deepseek-chat"
+
+
+def test_autogen_passes_reasoning_effort(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    fake = MagicMock(name="client")
+    with patch(
+        "agent.byo.autogen.runner.OpenAIChatCompletionClient", return_value=fake
+    ) as ctor:
+        create_model_client("gpt-5-mini", provider="openai", reasoning_effort="medium")
+
+    assert ctor.call_args.kwargs["reasoning_effort"] == "medium"
+
+
+def test_autogen_deepseek_ignores_reasoning_effort(monkeypatch) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds")
+    fake = MagicMock(name="client")
+    with patch(
+        "agent.byo.autogen.runner.OpenAIChatCompletionClient", return_value=fake
+    ) as ctor:
+        create_model_client(
+            "deepseek-chat", provider="deepseek", reasoning_effort="medium"
+        )
+
+    assert "reasoning_effort" not in ctor.call_args.kwargs
+
+
+def test_autogen_anthropic_ignores_reasoning_effort(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    fake = MagicMock(name="client")
+    with patch(
+        "agent.byo.autogen.runner.AnthropicChatCompletionClient", return_value=fake
+    ) as ctor:
+        create_model_client(
+            "claude-haiku-4-5", provider="anthropic", reasoning_effort="medium"
+        )
+
+    assert "reasoning_effort" not in ctor.call_args.kwargs


### PR DESCRIPTION
## Summary
- Wire `--reasoning-effort` / `agent.reasoning_effort` through `byo.langgraph`, `byo.mcp_agent`, and `byo.autogen` so GPT-5.x models can set effort.
- OpenAI/custom: pass through; DeepSeek ignores; Anthropic on langgraph via LangChain; mcp_agent/autogen Anthropic ignore (SDK clients have no effort field).
- `byo.mcp_agent` accepts `none`/`low`/`medium`/`high` only (mcp-agent SDK limit).

Fixes #40

## Test plan
- [x] Unit tests: `test_model_factory`, `test_openai_base_url`, `test_provider_env`
- [x] Docker e2e (`simple_bgp_link_down`, `-p openai -m gpt-5-mini`):
  - langgraph `-e minimal`
  - mcp_agent `-e low`
  - autogen `-e minimal`
- [ ] Optional: re-verify after merge with `-e medium` if preferred


Made with [Cursor](https://cursor.com)