### PR TITLE
Add `iosxr_simple_bgp` scenario and iosxr mcp server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use this index to find the shortest path for your task. The root [`README.md`](.
 | --- | --- |
 | Configure agents, labs, MCP, and benchmark runs | [Run configuration reference](configuration.md) |
 | Choose and deploy a lab | [Network scenario reference](network-scenarios.md) |
+| Load the Cisco XRd image for `iosxr_simple_bgp` | [Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md) |
 | Select and inject a fault | [Failure reference](failures.md) |
 | Use every CLI command and option | [CLI reference](cli-reference.md) |
 | Run labs on another host | [Remote lab execution](remote.md) |

--- a/docs/iosxr-xrd-setup.md
+++ b/docs/iosxr-xrd-setup.md
@@ -40,7 +40,25 @@ If the tag is missing, `nika env run iosxr_simple_bgp` fails fast with a
 `RuntimeError` that repeats the `docker load` / `docker tag` steps above
 instead of deploying a broken lab.
 
-## 4. Deploy
+
+
+## 4. Configure the host
+
+Cisco IOS XR (>=7.9.2) uses the official XRd Control Plane Docker image. You
+need to properly configure the host machine before running the XRd
+container. See
+[this tutorial](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-setting-up-host-environment-to-run-xrd)
+for more information.
+
+Particularly, you have to increase the `fs.inotify.max_user_instances` and
+`fs.inotify.max_user_watches` to at least 64000:
+
+```shell
+sysctl -w fs.inotify.max_user_instances=64000
+sysctl -w fs.inotify.max_user_watches=64000
+```
+
+## 5. Deploy
 
 ```shell
 uv run nika env run iosxr_simple_bgp

--- a/docs/iosxr-xrd-setup.md
+++ b/docs/iosxr-xrd-setup.md
@@ -1,0 +1,56 @@
+# Cisco IOS-XR (XRd) image setup
+
+`iosxr_simple_bgp` runs Cisco's XRd Control Plane container. Cisco's licensing
+means this image cannot be redistributed or auto-built like the
+`kathara/nika-*` images, so operators load and tag it by hand before
+deploying the scenario.
+
+## 1. Obtain the image
+
+Download the XRd Control Plane container tarball from Cisco (a CCO account
+with an XRd Control Plane entitlement is required, e.g. through Cisco
+Software Download or a Cisco Modeling Labs license). The file looks like:
+
+```text
+xrd-control-plane-container-x86_64-<version>.tgz
+```
+
+## 2. Load and tag it
+
+Load the tarball into Docker, then tag it to match the image reference the
+lab expects:
+
+```shell
+docker load -i xrd-control-plane-container-x86_64-<version>.tgz
+docker tag <loaded-repo>:<loaded-tag> ios-xr/xrd-control-plane:26.2.1
+```
+
+`ios-xr/xrd-control-plane:26.2.1` is the `IMAGE` constant in
+[`iosxr_simple_bgp/lab.py`](../src/nika/net_env/kathara/interdomain_routing/iosxr_simple_bgp/lab.py).
+If you load a different XRd version, either tag it as `26.2.1` or update that
+constant to match.
+
+## 3. Verify the tag
+
+```shell
+docker images | grep xrd-control-plane
+```
+
+If the tag is missing, `nika env run iosxr_simple_bgp` fails fast with a
+`RuntimeError` that repeats the `docker load` / `docker tag` steps above
+instead of deploying a broken lab.
+
+## 4. Deploy
+
+```shell
+uv run nika env run iosxr_simple_bgp
+```
+
+Each router runs privileged and with IPv6 enabled (set via Kathara device
+metadata in `lab.py`) — this is standard XRd Control Plane requirements, no
+extra host configuration beyond a working Kathara/Docker install.
+
+XRd's ZTP process can briefly race the container's network namespace setup
+right after boot; the router startup scripts already retry config
+application until that clears, so a slow first boot is expected and not a
+failure.

--- a/docs/network-scenarios.md
+++ b/docs/network-scenarios.md
@@ -21,7 +21,7 @@ uv sync --extra kathara
 uv sync --extra containerlab
 ```
 
-`min3clos` also calls `gnmic` and uses Nokia SR Linux and network-multitool images. `p4_int` needs the local `kathara/influxdb` image described under [P4 scenarios](#p4-scenarios). The Kubernetes scenarios download k3s and workload images during deployment.
+`min3clos` also calls `gnmic` and uses Nokia SR Linux and network-multitool images. `p4_int` needs the local `kathara/influxdb` image described under [P4 scenarios](#p4-scenarios). The Kubernetes scenarios download k3s and workload images during deployment. `iosxr_simple_bgp` needs a manually loaded Cisco XRd Control Plane image, see [Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md).
 
 ## Scenario catalog
 

--- a/src/agent/mock/mock_agent.py
+++ b/src/agent/mock/mock_agent.py
@@ -152,6 +152,8 @@ def _mock_diagnosis_tool_calls(
         router = _pick_router(devices) or (preferred[0] if preferred else None)
         if router and "kathara_frr_mcp_server" in server_names:
             calls.append(("frr_show_ip_route", {"router_name": router}))
+        elif router and "kathara_iosxr_mcp_server" in server_names:
+            calls.append(("iosxr_show_route", {"router_name": router}))
     return calls
 
 

--- a/src/nika/net_env/base.py
+++ b/src/nika/net_env/base.py
@@ -55,7 +55,7 @@ class NetworkEnvBase:
             image = machine_obj.get_image()
             if "p4" in image:
                 self.bmv2_switches.append(machine)
-            elif "frr" in image:
+            elif "frr" in image or "xrd" in image:
                 self.routers.append(machine)
             elif "base" in image or "nginx" in image or "wireguard" in image:
                 host_keys = ["pc", "client"]

--- a/src/nika/net_env/kathara/interdomain_routing/iosxr_simple_bgp/lab.py
+++ b/src/nika/net_env/kathara/interdomain_routing/iosxr_simple_bgp/lab.py
@@ -1,0 +1,203 @@
+"""IOS-XR (XRd Control Plane) equivalent of ``simple_bgp``.
+
+Requires the XRd Control Plane image manually loaded and tagged as
+``IMAGE`` below — Cisco's licensing means it cannot be built automatically
+like the ``kathara/nika-*`` images.
+"""
+
+import ipaddress
+
+from Kathara.manager.Kathara import Kathara
+from Kathara.model.Lab import Lab
+
+from nika.net_env.base import NetworkEnvBase
+from nika.net_env.kathara.utils.docker_files.docker_images import image_exists
+
+IMAGE = "ios-xr/xrd-control-plane:26.2.1"
+
+LINK_IFACE = "GigabitEthernet0/0/0/0"
+PC_IFACE = "GigabitEthernet0/0/0/1"
+CONFIG_FILE_PATH = "disk0:/startup-config.cfg"
+
+CLI_COMMAND = '/pkg/bin/xr_cli "{command}"'
+ZTP_APPLY_COMMAND = "/bin/bash -c 'source /pkg/bin/ztp_helper.sh; xrapply {file}'"
+
+ROUTERS = {
+    "router1": {
+        "as": 1,
+        "link_ip": ipaddress.ip_interface("193.10.11.1/24"),
+        "peer_ip": ipaddress.ip_address("193.10.11.2"),
+        "peer_as": 2,
+        "pc_ip": ipaddress.ip_interface("195.11.14.1/24"),
+        "network": ipaddress.ip_network("195.11.14.0/24"),
+    },
+    "router2": {
+        "as": 2,
+        "link_ip": ipaddress.ip_interface("193.10.11.2/24"),
+        "peer_ip": ipaddress.ip_address("193.10.11.1"),
+        "peer_as": 1,
+        "pc_ip": ipaddress.ip_interface("200.1.1.1/24"),
+        "network": ipaddress.ip_network("200.1.1.0/24"),
+    },
+}
+
+
+def _build_startup_config(name: str, router: dict) -> str:
+    return "\n".join(
+        [
+            f"hostname {name}",
+            "!",
+            f"interface {LINK_IFACE}",
+            f" ipv4 address {router['link_ip']}",
+            " no shutdown",
+            "!",
+            f"interface {PC_IFACE}",
+            f" ipv4 address {router['pc_ip']}",
+            " no shutdown",
+            "!",
+            "route-policy PASS",
+            " pass",
+            "end-policy",
+            "!",
+            f"router bgp {router['as']}",
+            f" bgp router-id {router['link_ip'].ip}",
+            " address-family ipv4 unicast",
+            f"  network {router['network']}",
+            " !",
+            f" neighbor {router['peer_ip']}",
+            f"  remote-as {router['peer_as']}",
+            "  address-family ipv4 unicast",
+            "   route-policy PASS in",
+            "   route-policy PASS out",
+            "  !",
+            " !",
+            "!",
+            "end",
+            "",
+        ]
+    )
+
+
+def _build_startup_script(config_path: str) -> list:
+    check_cmd_1 = (
+        CLI_COMMAND.format(command="show run")
+        + " | egrep -e 'No configuration change' -e 'No such file or directory'"
+    )
+    check_cmd_2 = (
+        CLI_COMMAND.format(command=f"sh ip interface {LINK_IFACE}")
+        + " | egrep -e 'ipv4 protocol is Down'"
+    )
+    check_cmd_3 = (
+        CLI_COMMAND.format(command=f"sh ipv6 interface {LINK_IFACE}")
+        + " | egrep -e 'ipv6 protocol is Down'"
+    )
+
+    # xrapply can fail with "Cannot open network namespace" if it runs the
+    # instant Kathara's startup script starts, before XR has finished
+    # creating the "xrnns" netns: the config is silently never applied and
+    # the container stays "running" with the data interfaces down. Retry
+    # until that specific error goes away.
+    apply_cmd = ZTP_APPLY_COMMAND.format(file=config_path)
+    apply_with_retry = "\n".join(
+        [
+            "apply_ok=0",
+            "for _xr_apply_try in $(seq 1 40); do",
+            f"  _xr_apply_out=$({apply_cmd} 2>&1)",
+            '  echo "$_xr_apply_out"',
+            '  if ! echo "$_xr_apply_out" | grep -q "Cannot open network namespace"; then',
+            "    apply_ok=1",
+            "    break",
+            "  fi",
+            "  sleep 3",
+            "done",
+            '[[ "$apply_ok" -eq 1 ]] || echo "ERROR: xrapply did not succeed after retries"',
+        ]
+    )
+
+    return [
+        "pgrep xrd-startup; while [[ $? -eq 0 ]]; do sleep 3; pgrep xrd-startup; done",
+        check_cmd_1,
+        f"while [[ $? -eq 0 ]]; do sleep 3; {check_cmd_1}; done",
+        check_cmd_2,
+        f"while [[ $? -eq 0 ]]; do sleep 3; {check_cmd_2}; done",
+        check_cmd_3,
+        f"while [[ $? -eq 0 ]]; do sleep 3; {check_cmd_3}; done",
+        "source /pkg/bin/ztp_helper.sh; ztp_disable; ztp_kill_all; killall -9 pyztp2",
+        apply_with_retry,
+    ]
+
+
+class IosXrSimpleBGP(NetworkEnvBase):
+    LAB_NAME = "iosxr_simple_bgp"
+    VERIFY_MAX_WAIT_SEC = 480
+    VERIFY_RETRY_DELAY_SEC = 10
+    TOPO_LEVEL = "easy"
+    TOPO_SIZE = None
+    TAGS = ["arp", "link", "bgp", "icmp", "iosxr", "pc"]
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.lab = Lab(self.LAB_NAME)
+        self.name = self.LAB_NAME
+        self.instance = Kathara.get_instance()
+        self.desc = "A simple BGP network with two IOS-XR (XRd) routers and two pcs."
+
+        for router_name, router in ROUTERS.items():
+            machine = self.lab.new_machine(router_name, **{"image": IMAGE})
+            machine.add_meta("privileged", True)
+            machine.add_meta("ipv6", True)
+            machine.add_meta(
+                "env",
+                f"XR_INTERFACES=linux:eth0,xr_name={LINK_IFACE};linux:eth1,xr_name={PC_IFACE}",
+            )
+            machine.add_meta("env", "XR_ZTP_ENABLE=0")
+            machine.create_file_from_string(
+                _build_startup_config(router_name, router), CONFIG_FILE_PATH
+            )
+            self.lab.create_file_from_list(
+                _build_startup_script(CONFIG_FILE_PATH), f"{router_name}.startup"
+            )
+
+        pc1 = self.lab.new_machine("pc1", **{"image": "kathara/nika-base"})
+        pc2 = self.lab.new_machine("pc2", **{"image": "kathara/nika-base"})
+
+        self.lab.connect_machine_to_link("router1", "A")
+        self.lab.connect_machine_to_link("router2", "A")
+
+        self.lab.connect_machine_to_link("router1", "B")
+        self.lab.connect_machine_to_link(pc1.name, "B")
+
+        self.lab.connect_machine_to_link("router2", "C")
+        self.lab.connect_machine_to_link(pc2.name, "C")
+
+        self.lab.create_file_from_string(
+            "ip addr add 195.11.14.2/24 dev eth0\n"
+            "ip route add default via 195.11.14.1 dev eth0\n",
+            "pc1.startup",
+        )
+        self.lab.create_file_from_string(
+            "ip addr add 200.1.1.2/24 dev eth0\n"
+            "ip route add default via 200.1.1.1 dev eth0\n",
+            "pc2.startup",
+        )
+
+        self.load_machines()
+
+    def deploy(self):
+        if not image_exists(IMAGE):
+            raise RuntimeError(
+                f"XRd Control Plane image {IMAGE!r} not found locally. Cisco's "
+                "license requires loading it by hand, e.g.:\n"
+                "  docker load -i xrd-control-plane-container-x86.<version>.tgz\n"
+                f"  docker tag <loaded-tag> {IMAGE}"
+            )
+        super().deploy()
+
+    def verify_lab(self) -> dict:
+        from nika.net_env.kathara.interdomain_routing.iosxr_simple_bgp.verify import (
+            verify_iosxr_simple_bgp_lab,
+        )
+
+        return verify_iosxr_simple_bgp_lab(
+            self._build_runtime(), scenario_name=self.LAB_NAME
+        )

--- a/src/nika/net_env/kathara/interdomain_routing/iosxr_simple_bgp/verify.py
+++ b/src/nika/net_env/kathara/interdomain_routing/iosxr_simple_bgp/verify.py
@@ -1,0 +1,63 @@
+"""Startup verification signals for the iosxr_simple_bgp scenario."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from nika.net_env.kathara.interdomain_routing.iosxr_simple_bgp.lab import LINK_IFACE
+from nika.net_env.verify import (
+    build_lab_verify_result,
+    default_route_via,
+    exec_or_empty,
+    host_has_ipv4,
+    nodes_deployed,
+    ping_ok,
+)
+from nika.runtime.base import LabRuntime
+
+
+def _iosxr_interface_up(runtime: LabRuntime, router: str, interface: str) -> bool:
+    # nika's exec wrapping (ShellResolver.wrap_shell_command) escapes double
+    # quotes for a context where they don't need it, splitting a
+    # double-quoted xr_cli argument into several stray tokens. Single quotes
+    # round-trip correctly, so xr_cli's argument is quoted with those instead.
+    output = exec_or_empty(runtime, router, "/pkg/bin/xr_cli 'show ip interface brief'")
+    pattern = re.compile(rf"{re.escape(interface)}\s+\S+\s+Up\s+Up")
+    return bool(pattern.search(output))
+
+
+def _iosxr_bgp_established(
+    runtime: LabRuntime, router: str, *, min_neighbors: int = 1
+) -> bool:
+    output = exec_or_empty(
+        runtime, router, "/pkg/bin/xr_cli 'show bgp summary'", timeout=20
+    )
+    established = 0
+    for line in output.splitlines():
+        fields = line.split()
+        if fields and fields[-1].isdigit():
+            established += 1
+    return established >= min_neighbors
+
+
+def verify_iosxr_simple_bgp_lab(
+    runtime: LabRuntime, *, scenario_name: str
+) -> dict[str, Any]:
+    expected = ("router1", "router2", "pc1", "pc2")
+    checks = {
+        "nodes_deployed": nodes_deployed(runtime, expected),
+        "router1_iface_up": _iosxr_interface_up(runtime, "router1", LINK_IFACE),
+        "router2_iface_up": _iosxr_interface_up(runtime, "router2", LINK_IFACE),
+        "router1_bgp_established": _iosxr_bgp_established(runtime, "router1"),
+        "pc1_ipv4": host_has_ipv4(runtime, "pc1", "195.11.14.2"),
+        "pc2_ipv4": host_has_ipv4(runtime, "pc2", "200.1.1.2"),
+        "pc1_default_route": default_route_via(runtime, "pc1", "195.11.14.1"),
+        "pc1_gateway_reachable": ping_ok(runtime, "pc1", "195.11.14.1"),
+        "pc1_to_pc2_reachable": ping_ok(runtime, "pc1", "200.1.1.2"),
+    }
+    return build_lab_verify_result(
+        scenario_name=scenario_name,
+        verified=all(checks.values()),
+        checks=checks,
+    )

--- a/src/nika/net_env/net_env_pool.py
+++ b/src/nika/net_env/net_env_pool.py
@@ -166,6 +166,13 @@ _NET_ENV_SPECS: dict[str, NetEnvSpec] = {
         tags=("arp", "link", "mac", "bgp", "icmp", "frr", "pc"),
         supported_backends=("kathara",),
     ),
+    "iosxr_simple_bgp": NetEnvSpec(
+        lab_name="iosxr_simple_bgp",
+        module="nika.net_env.kathara.interdomain_routing.iosxr_simple_bgp.lab",
+        class_name="IosXrSimpleBGP",
+        tags=("arp", "link", "bgp", "icmp", "iosxr", "pc"),
+        supported_backends=("kathara",),
+    ),
     "isp": NetEnvSpec(
         lab_name="isp",
         module="nika.net_env.kathara.isp.isp.lab",

--- a/src/nika/service/kathara/__init__.py
+++ b/src/nika/service/kathara/__init__.py
@@ -2,6 +2,7 @@ from nika.service.kathara.base_api import KatharaBaseAPI
 from nika.service.kathara.bmv2_api import BMv2APIMixin, KatharaBMv2API
 from nika.service.kathara.frr_api import FRRAPIMixin, KatharaFRRAPI
 from nika.service.kathara.intf_api import IntfAPIMixin, KatharaIntfAPI
+from nika.service.kathara.iosxr_api import IOSXRAPIMixin, KatharaIOSXRAPI
 from nika.service.kathara.k8s_api import KatharaK8sAPI, K8sAPIMixin
 from nika.service.kathara.nftable_api import KatharaNFTableAPI, NFTableMixin
 from nika.service.kathara.tc_api import KatharaTCAPI, TCMixin
@@ -13,6 +14,7 @@ __all__ = [
     "KatharaBMv2API",
     "KatharaFRRAPI",
     "KatharaIntfAPI",
+    "KatharaIOSXRAPI",
     "KatharaNFTableAPI",
     "KatharaTCAPI",
     "KatharaTelemetryAPI",
@@ -25,6 +27,7 @@ class KatharaAPIALL(
     BMv2APIMixin,
     FRRAPIMixin,
     IntfAPIMixin,
+    IOSXRAPIMixin,
     NFTableMixin,
     TCMixin,
     TelemetryAPIMixin,

--- a/src/nika/service/kathara/base_api.py
+++ b/src/nika/service/kathara/base_api.py
@@ -434,7 +434,7 @@ class KatharaBaseAPI:
             image = machine_obj.get_image()
             if "p4" in image:
                 self.bmv2_switches.append(machine)
-            elif "frr" in image:
+            elif "frr" in image or "xrd" in image:
                 self.routers.append(machine)
             elif "base" in image or "nginx" in image or "wireguard" in image:
                 host_keys = ["pc", "client"]

--- a/src/nika/service/kathara/iosxr_api.py
+++ b/src/nika/service/kathara/iosxr_api.py
@@ -1,0 +1,10 @@
+"""Kathara IOS-XR API (re-exported from shared lab service)."""
+
+from nika.service.kathara.base_api import KatharaBaseAPI
+from nika.service.lab.iosxr_api import IOSXRAPIMixin
+
+__all__ = ["IOSXRAPIMixin", "KatharaIOSXRAPI"]
+
+
+class KatharaIOSXRAPI(KatharaBaseAPI, IOSXRAPIMixin):
+    pass

--- a/src/nika/service/lab/iosxr_api.py
+++ b/src/nika/service/lab/iosxr_api.py
@@ -1,0 +1,46 @@
+"""Shared Cisco IOS-XR (XRd) routing API for Kathara labs."""
+
+from __future__ import annotations
+
+from nika.service.lab.protocols import SupportsExec
+
+CLI_COMMAND = "/pkg/bin/xr_cli '{command}'"
+
+
+def _single_quote(value: str) -> str:
+    # nika's exec wrapping over-escapes double quotes (turns them into stray
+    # tokens), so nested arguments must stay single-quoted all the way down;
+    # this is the standard POSIX close/insert-literal-quote/reopen trick.
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+class IOSXRAPIMixin:
+    """XRd Control Plane operations via ``exec_cmd``."""
+
+    def uses_iosxr_router(self: SupportsExec, device_name: str) -> bool:
+        output = self.exec_cmd(
+            device_name, "test -x /pkg/bin/xr_cli && echo yes || true"
+        )
+        return "yes" in output
+
+    def iosxr_exec(self: SupportsExec, device_name: str, command: str) -> str:
+        return self.exec_cmd(device_name, CLI_COMMAND.format(command=command))
+
+    def iosxr_get_bgp_conf(self: SupportsExec, device_name: str) -> str:
+        return self.iosxr_exec(device_name, "show running-config router bgp")
+
+    def iosxr_show_running_config(self: SupportsExec, device_name: str) -> str:
+        return self.iosxr_exec(device_name, "show running-config")
+
+    def iosxr_show_route(self: SupportsExec, device_name: str) -> str:
+        return self.iosxr_exec(device_name, "show route")
+
+    def iosxr_apply_config(
+        self: SupportsExec, device_name: str, config_lines: list[str]
+    ) -> str:
+        content = "\\n".join(config_lines)
+        inner = (
+            f"source /pkg/bin/ztp_helper.sh; xrapply_string {_single_quote(content)}"
+        )
+        command = f"/bin/bash -c {_single_quote(inner)}"
+        return self.exec_cmd(device_name, command)

--- a/src/nika/service/mcp_gateway/app.py
+++ b/src/nika/service/mcp_gateway/app.py
@@ -38,6 +38,10 @@ _MCP_MODULE_ATTRS: dict[str, tuple[str, str]] = {
         "nika.service.mcp_server.kathara.frr_server",
         "mcp",
     ),
+    "kathara_iosxr_mcp_server": (
+        "nika.service.mcp_server.kathara.iosxr_server",
+        "mcp",
+    ),
     "kathara_bmv2_mcp_server": (
         "nika.service.mcp_server.kathara.bmv2_server",
         "mcp",

--- a/src/nika/service/mcp_server/kathara/iosxr_server.py
+++ b/src/nika/service/mcp_server/kathara/iosxr_server.py
@@ -1,0 +1,64 @@
+from mcp.server.fastmcp import FastMCP
+
+from nika.service.kathara import KatharaIOSXRAPI
+from nika.service.mcp_server.session_context import get_lab_name
+from nika.utils.errors import safe_tool
+
+# Initialize FastMCP server
+mcp = FastMCP("kathara_iosxr_mcp_server")
+
+
+@safe_tool
+@mcp.tool()
+def iosxr_get_bgp_conf(router_name: str) -> str:
+    """Get the BGP configuration from the IOS-XR router.
+
+    Args:
+        router_name (str): The name of the router.
+
+    Returns:
+        str: The BGP configuration from the IOS-XR router.
+    """
+    kathara_api = KatharaIOSXRAPI(lab_name=get_lab_name())
+    return kathara_api.iosxr_get_bgp_conf(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def iosxr_show_running_config(router_name: str) -> str:
+    """Get the running configuration from the IOS-XR router.
+
+    Args:
+        router_name (str): The name of the router.
+    Returns:
+        str: The running configuration from the IOS-XR router.
+    """
+    kathara_api = KatharaIOSXRAPI(lab_name=get_lab_name())
+    return kathara_api.iosxr_show_running_config(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def iosxr_show_route(router_name: str) -> str:
+    """Get the IP routing table from the IOS-XR router.
+
+    Args:
+        router_name (str): The name of the router.
+    Returns:
+        str: The IP routing table from the IOS-XR router.
+    """
+    kathara_api = KatharaIOSXRAPI(lab_name=get_lab_name())
+    return kathara_api.iosxr_show_route(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def iosxr_exec(router_name: str, command: str) -> str:
+    """Execute an xr_cli command on an IOS-XR router."""
+    kathara_api = KatharaIOSXRAPI(lab_name=get_lab_name())
+    return kathara_api.iosxr_exec(router_name, command)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport="stdio")

--- a/src/nika/service/mcp_server/registry.py
+++ b/src/nika/service/mcp_server/registry.py
@@ -14,6 +14,7 @@ ENV_SESSION_BACKEND = "NIKA_SESSION_BACKEND"
 
 # Keyword tokens (from scenario name and net-env TAGS) that trigger optional servers.
 ROUTING_KEYWORDS = frozenset({"bgp", "ospf", "rip", "frr", "routing"})
+IOSXR_KEYWORDS = frozenset({"iosxr", "xrd"})
 SWITCH_KEYWORDS = frozenset({"p4", "bmv2", "sdn", "bloom", "mpls", "int", "counter"})
 TELEMETRY_KEYWORDS = frozenset({"telemetry"})
 KUBERNETES_KEYWORDS = frozenset({"kubernetes", "k3s", "k8s"})
@@ -60,6 +61,12 @@ MCP_SERVER_SPECS: dict[str, MCPServerSpec] = {
         backend="kathara",
         role="routing",
         module="kathara/frr_server.py",
+    ),
+    "kathara_iosxr_mcp_server": MCPServerSpec(
+        name="kathara_iosxr_mcp_server",
+        backend="kathara",
+        role="routing",
+        module="kathara/iosxr_server.py",
     ),
     "kathara_bmv2_mcp_server": MCPServerSpec(
         name="kathara_bmv2_mcp_server",
@@ -162,6 +169,8 @@ def select_diagnosis_servers(
 
     if backend == "containerlab" and tokens & ROUTING_KEYWORDS:
         servers.append("containerlab_srl_mcp_server")
+    elif backend != "containerlab" and tokens & IOSXR_KEYWORDS:
+        servers.append("kathara_iosxr_mcp_server")
     elif backend != "containerlab" and tokens & ROUTING_KEYWORDS:
         servers.append("kathara_frr_mcp_server")
     if tokens & SWITCH_KEYWORDS:

--- a/tests/nika/net_env/test_iosxr_simple_bgp_verify.py
+++ b/tests/nika/net_env/test_iosxr_simple_bgp_verify.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from nika.net_env.kathara.interdomain_routing.iosxr_simple_bgp.verify import (
+    verify_iosxr_simple_bgp_lab,
+)
+from tests.support.net_env import assert_verify_success
+
+NODES = {"router1", "router2", "pc1", "pc2"}
+HOST_ADDRS = {
+    "pc1": ("195.11.14.2",),
+    "pc2": ("200.1.1.2",),
+}
+
+
+class FakeRuntime:
+    def __init__(self, *, nodes: set[str] | None = None) -> None:
+        self.nodes = nodes or NODES
+
+    def list_nodes(self) -> list[str]:
+        return sorted(self.nodes)
+
+    def exec(self, host: str, command: str, timeout: float = 10.0) -> str:
+        if command == "/pkg/bin/xr_cli 'show ip interface brief'":
+            return "GigabitEthernet0/0/0/0 10.0.0.1 Up Up default"
+        if command == "/pkg/bin/xr_cli 'show bgp summary'":
+            return "193.10.11.2 4 2 10 12 5 0 0 00:02:15 3\n"
+        if command.startswith("ping -c 1"):
+            return "1 received"
+        if command.startswith("ip -4 -o addr show"):
+            return "\n".join(f"inet {addr}/24" for addr in HOST_ADDRS.get(host, ()))
+        if command == "ip route show default":
+            return "default via 195.11.14.1 dev eth0"
+        return ""
+
+
+def test_iosxr_simple_bgp_verify_passes() -> None:
+    assert_verify_success(verify_iosxr_simple_bgp_lab(FakeRuntime(), scenario_name="x"))
+
+
+def test_iosxr_simple_bgp_verify_fails_on_missing_node() -> None:
+    result = verify_iosxr_simple_bgp_lab(
+        FakeRuntime(nodes=NODES - {"pc2"}), scenario_name="x"
+    )
+    assert not result["verified"]
+    assert not result["checks"]["nodes_deployed"]


### PR DESCRIPTION
This pull request adds support for Cisco IOS-XR (XRd Control Plane) routers in the Kathara-based network emulation environment. It introduces a new scenario (`iosxr_simple_bgp`), implements the necessary API and MCP server support for IOS-XR devices, and updates documentation to guide users through the required manual image setup due to Cisco licensing restrictions. The changes also ensure that IOS-XR routers are correctly recognized and handled throughout the codebase.

**New IOS-XR scenario and documentation:**

- Added a new `iosxr_simple_bgp` scenario that builds a simple BGP network using Cisco XRd routers, including lab construction, device configuration, and verification logic. The scenario requires the XRd image to be manually loaded and tagged due to licensing. 
- Added detailed documentation (`iosxr-xrd-setup.md`) and updated references in `README.md` and `network-scenarios.md` to instruct users on obtaining, loading, and tagging the IOS-XR image for use in labs.

**API and MCP server integration for IOS-XR:**

- Implemented a shared IOS-XR API mixin (`IOSXRAPIMixin`) for common router operations (show config, show route, apply config, etc.), and integrated it into the Kathara API layer, including a new `KatharaIOSXRAPI` class.
- Added a new MCP server module (`kathara_iosxr_mcp_server`) exposing IOS-XR router management tools via FastMCP, and registered it in the MCP gateway. 

**Core framework and recognition updates:**

- Updated machine-loading logic in both the environment base and Kathara API to recognize XRd images as routers, ensuring correct device classification and management. 
- Registered the new scenario in the environment pool for proper discovery and instantiation.

**Mock and testing improvements:**

- Enhanced the mock agent to simulate IOS-XR route queries for scenarios using XRd routers.