### PR TITLE
Add routeros_simple_bgp scenario and routeros mcp server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use this index to find the shortest path for your task. The root [`README.md`](.
 | Configure agents, labs, MCP, and benchmark runs | [Run configuration reference](configuration.md) |
 | Choose and deploy a lab | [Network scenario reference](network-scenarios.md) |
 | Load the Cisco XRd image for `iosxr_simple_bgp` | [Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md) |
+| Build the RouterOS image for `routeros_simple_bgp` | [MikroTik RouterOS (vrnetlab) image setup](mikrotik-routeros-setup.md) |
 | Select and inject a fault | [Failure reference](failures.md) |
 | Use every CLI command and option | [CLI reference](cli-reference.md) |
 | Run labs on another host | [Remote lab execution](remote.md) |

--- a/docs/mikrotik-routeros-setup.md
+++ b/docs/mikrotik-routeros-setup.md
@@ -1,0 +1,84 @@
+# MikroTik RouterOS (vrnetlab) image setup
+
+`routeros_simple_bgp` runs a MikroTik RouterOS Cloud Hosted Router (CHR)
+image wrapped by `vrnetlab`. MikroTik's licensing means this image cannot be
+redistributed or auto-built like the `kathara/nika-*` images, so operators
+download and build it by hand before deploying the scenario.
+
+Unlike `iosxr_simple_bgp`'s XRd Control Plane, which runs as a native
+container process, RouterOS via vrnetlab boots a full QEMU VM inside the
+container. That changes both the build story and the host prerequisites.
+
+## 1. Obtain the image
+
+Download a Cloud Hosted Router (CHR) image from
+[mikrotik.com/download](https://mikrotik.com/download): the `.vmdk` variant
+for x86, or `.vdi` for arm64.
+
+## 2. Build the image
+
+Clone upstream `vrnetlab` and build the RouterOS image from its
+`mikrotik/routeros` directory:
+
+```shell
+git clone https://github.com/hellt/vrnetlab
+cd vrnetlab/mikrotik/routeros
+# copy the downloaded CHR .vmdk/.vdi into this directory
+make docker-image
+```
+
+No Dockerfile changes are needed for management access: `sshpass` and
+`ssh` already ship with vrnetlab's own base image
+(`ghcr.io/srl-labs/vrnetlab-base:0.3.0`). NIKA execs `sshpass`+`ssh` into
+the container to reach RouterOS's internal management API (see
+[`routeros_api.py`](../src/nika/service/lab/routeros_api.py)) with no
+extra packages to install.
+
+Do not change the image's `ENTRYPOINT`/`--connection-mode`: the scenario
+passes `--connection-mode macvtap` as a Kathara machine argument at deploy
+time (see `lab.py`), because Kathara attaches interfaces before the
+container starts, and vrnetlab's default `vrxcon`/`tc` datapaths expect a
+data interface to appear only after boot.
+
+Then tag the built image to match the `IMAGE` constant in
+[`routeros_simple_bgp/lab.py`](../src/nika/net_env/kathara/interdomain_routing/routeros_simple_bgp/lab.py):
+
+```shell
+docker tag <built-tag> vrnetlab/mikrotik_routeros:7.21.5
+```
+
+If you build a different RouterOS version, either tag it as `7.21.5` or
+update that constant to match.
+
+## 3. Verify the tag
+
+```shell
+docker images | grep routeros
+```
+
+If the tag is missing, `nika env run routeros_simple_bgp` fails fast with a
+`RuntimeError` that repeats the build/tag steps above instead of deploying a
+broken lab.
+
+## 4. Configure the host
+
+RouterOS/vrnetlab boots a full QEMU VM per router, unlike XRd's native
+container process. The host needs KVM / nested virtualization available:
+
+- `/dev/kvm` must exist and be usable.
+- If the host itself is a VM, nested virtualization must be enabled at the
+  hypervisor level.
+
+Without KVM, boot is dramatically slower or may not complete at all. No
+`inotify` limit tuning is needed here — that requirement was specific to
+XRd.
+
+## 5. Deploy
+
+```shell
+nika env run routeros_simple_bgp
+```
+
+Boot is slower than the FRR and XRd scenarios because each router boots a
+nested VM; the scenario's verification window accounts for this, so a slow
+first boot is expected and not a failure.

--- a/docs/network-scenarios.md
+++ b/docs/network-scenarios.md
@@ -1,6 +1,6 @@
 # Network scenario reference
 
-This reference helps benchmark operators choose and configure a NIKA network scenario. This checkout registers 16 scenario IDs. Fifteen use one backend; `isp` supports both Kathara and Containerlab.
+This reference helps benchmark operators choose and configure a NIKA network scenario. This checkout registers 18 scenario IDs. Seventeen use one backend; `isp` supports both Kathara and Containerlab.
 
 The [`net_env_pool.py`](../src/nika/net_env/net_env_pool.py) registry defines the authoritative scenario IDs, backends, tags, and size controls. Backend implementations live under [`net_env/`](../src/nika/net_env/). Confirm the installed checkout with:
 
@@ -21,7 +21,7 @@ uv sync --extra kathara
 uv sync --extra containerlab
 ```
 
-`min3clos` also calls `gnmic` and uses Nokia SR Linux and network-multitool images. `p4_int` needs the local `kathara/influxdb` image described under [P4 scenarios](#p4-scenarios). The Kubernetes scenarios download k3s and workload images during deployment. `iosxr_simple_bgp` needs a manually loaded Cisco XRd Control Plane image, see [Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md).
+`min3clos` also calls `gnmic` and uses Nokia SR Linux and network-multitool images. `p4_int` needs the local `kathara/influxdb` image described under [P4 scenarios](#p4-scenarios). The Kubernetes scenarios download k3s and workload images during deployment. `iosxr_simple_bgp` needs a manually loaded Cisco XRd Control Plane image, see [Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md). `routeros_simple_bgp` needs a manually built RouterOS `vrnetlab` image, see [MikroTik RouterOS (vrnetlab) image setup](mikrotik-routeros-setup.md).
 
 ## Scenario catalog
 
@@ -33,6 +33,8 @@ uv sync --extra containerlab
 | `ospf_enterprise_dhcp` | Kathara | `-s s\|m\|l` | OSPF enterprise with DHCP, DNS, HTTP, and NGINX |
 | `rip_small_internet_vpn` | Kathara | `-s s\|m\|l` | RIP mini-Internet with a WireGuard overlay |
 | `simple_bgp` | Kathara | Fixed | Two FRR ASes with one host in each AS |
+| `iosxr_simple_bgp` | Kathara | Fixed | Two Cisco XRd ASes with one host in each AS |
+| `routeros_simple_bgp` | Kathara | Fixed | Two MikroTik RouterOS ASes with one host in each AS |
 | `sdn_star` | Kathara | `-s s\|m\|l` | POX and Open vSwitch star |
 | `sdn_clos` | Kathara | `-s s\|m\|l` | POX and Open vSwitch leaf-spine Clos |
 | `p4_bloom_filter` | Kathara | Fixed | BMv2 flow-counting Bloom filter pipeline |
@@ -152,6 +154,38 @@ pc1 -- router1 == eBGP == router2 -- pc2
 ```
 
 `pc1` uses `195.11.14.2/24`; `pc2` uses `200.1.1.2/24`. Each FRR router advertises its host-facing network. Use this small topology for fast BGP and end-to-end routing experiments. Verification checks the BGP session, routes, default gateway, and traffic between the hosts.
+
+### `iosxr_simple_bgp`
+
+`iosxr_simple_bgp` is the same fixed two-AS topology, rendered with Cisco XRd
+Control Plane routers instead of FRR:
+
+```text
+pc1 -- router1 == eBGP == router2 -- pc2
+```
+
+Addressing matches `simple_bgp`. Requires a manually loaded XRd image, see
+[Cisco IOS-XR (XRd) image setup](iosxr-xrd-setup.md). Use this scenario for
+IOS-XR-specific troubleshooting and diagnosis on a small, fast-booting
+topology. Verification checks the BGP session, routes, default gateway, and
+traffic between the hosts.
+
+### `routeros_simple_bgp`
+
+`routeros_simple_bgp` is the same fixed two-AS topology, rendered with
+MikroTik RouterOS routers instead of FRR:
+
+```text
+pc1 -- router1 == eBGP == router2 -- pc2
+```
+
+Addressing matches `simple_bgp`. Requires a manually built RouterOS
+`vrnetlab` image, see
+[MikroTik RouterOS (vrnetlab) image setup](mikrotik-routeros-setup.md). Each
+router boots a nested QEMU VM, so first boot is slower than the FRR and XRd
+variants. Use this scenario for RouterOS-specific troubleshooting and
+diagnosis. Verification checks the BGP session, routes, default gateway, and
+traffic between the hosts.
 
 ## SDN scenarios
 

--- a/src/agent/mock/mock_agent.py
+++ b/src/agent/mock/mock_agent.py
@@ -154,6 +154,8 @@ def _mock_diagnosis_tool_calls(
             calls.append(("frr_show_ip_route", {"router_name": router}))
         elif router and "kathara_iosxr_mcp_server" in server_names:
             calls.append(("iosxr_show_route", {"router_name": router}))
+        elif router and "kathara_routeros_mcp_server" in server_names:
+            calls.append(("routeros_show_route", {"router_name": router}))
     return calls
 
 

--- a/src/nika/net_env/base.py
+++ b/src/nika/net_env/base.py
@@ -55,7 +55,7 @@ class NetworkEnvBase:
             image = machine_obj.get_image()
             if "p4" in image:
                 self.bmv2_switches.append(machine)
-            elif "frr" in image or "xrd" in image:
+            elif "frr" in image or "xrd" in image or "routeros" in image:
                 self.routers.append(machine)
             elif "base" in image or "nginx" in image or "wireguard" in image:
                 host_keys = ["pc", "client"]
@@ -111,6 +111,10 @@ class NetworkEnvBase:
         topology = sorted(topology.items(), key=lambda x: x[0])
         topo_list = []
         for link, machines in topology:
+            # A link with a single endpoint (e.g. vrnetlab's reserved
+            # placeholder interface) isn't a pairwise connection to report.
+            if len(machines) < 2:
+                continue
             topo_list.append((machines[0], machines[1]))
         return topo_list
 

--- a/src/nika/net_env/kathara/interdomain_routing/routeros_simple_bgp/lab.py
+++ b/src/nika/net_env/kathara/interdomain_routing/routeros_simple_bgp/lab.py
@@ -1,0 +1,175 @@
+"""MikroTik RouterOS (vrnetlab) equivalent of ``simple_bgp``.
+
+Requires a locally built ``vrnetlab/mikrotik/routeros`` image tagged as
+``IMAGE`` below — MikroTik's licensing means the CHR disk image cannot be
+redistributed or auto-built like the ``kathara/nika-*`` images.
+
+RouterOS via vrnetlab boots a full QEMU VM inside the container (unlike XRd,
+which is a native container process). vrnetlab always reserves the first
+container interface (``eth0`` / RouterOS ``ether1``) for its own internal
+management bridge, so each router here starts with an isolated placeholder
+link that consumes Kathara interface index 0 before the real data links are
+attached — see the two ``connect_machine_to_link`` calls below.
+"""
+
+import ipaddress
+
+from Kathara.manager.Kathara import Kathara
+from Kathara.model.Lab import Lab
+
+from nika.net_env.base import NetworkEnvBase
+from nika.net_env.kathara.utils.docker_files.docker_images import image_exists
+
+IMAGE = "vrnetlab/mikrotik_routeros:7.21.5"
+
+# vrnetlab's own fixed, non-secret internal defaults for RouterOS's mgmt IP,
+# which sits on an internal bridge reachable only via `docker exec` into the
+# container's network namespace — never exposed on the Kathara data plane.
+MGMT_USER = "vrnetlab"
+MGMT_PASSWORD = "VR-netlab9"
+MGMT_ADDR = "172.31.255.30"
+
+# Real data-link count per router (router-to-router + router-to-pc). Must
+# track this exactly: vrnetlab's boot blocks with no timeout until it sees
+# CLAB_INTFS + 1 total container interfaces, so setting this too high hangs
+# the VM forever waiting for interfaces this scenario never attaches.
+CLAB_INTFS = 2
+
+LINK_IFACE = "ether2"
+PC_IFACE = "ether3"
+
+ROUTERS = {
+    "router1": {
+        "as": 1,
+        "link_ip": ipaddress.ip_interface("193.10.11.1/24"),
+        "peer_ip": ipaddress.ip_address("193.10.11.2"),
+        "peer_as": 2,
+        "pc_ip": ipaddress.ip_interface("195.11.14.1/24"),
+    },
+    "router2": {
+        "as": 2,
+        "link_ip": ipaddress.ip_interface("193.10.11.2/24"),
+        "peer_ip": ipaddress.ip_address("193.10.11.1"),
+        "peer_as": 1,
+        "pc_ip": ipaddress.ip_interface("200.1.1.1/24"),
+    },
+}
+
+
+def _build_startup_config(name: str, router: dict) -> str:
+    # RouterOS auto-imports a file named exactly `config.auto.rsc` as soon as
+    # vrnetlab FTPs it in (MikroTik's *.auto.rsc convention); the importer
+    # wants terse, single-line commands, so this is authored directly in
+    # that form.
+    #
+    # This targets RouterOS 7's BGP menu, which replaced ROS6's: there is no
+    # implicit "default" instance, so one must be created explicitly with
+    # its own `as=`/`router-id=`; `/routing bgp connection add` takes no
+    # `router-id=` of its own (it comes from the instance); and
+    # `/routing bgp network add` no longer exists — the PC-facing subnet is
+    # advertised by redistributing connected routes instead.
+    return "\n".join(
+        [
+            f"/system identity set name={name}",
+            f"/ip address add address={router['link_ip']} interface={LINK_IFACE}",
+            f"/ip address add address={router['pc_ip']} interface={PC_IFACE}",
+            (
+                "/routing bgp instance add name=default "
+                f"as={router['as']} router-id={router['link_ip'].ip}"
+            ),
+            (
+                "/routing bgp connection add name=to-peer instance=default "
+                f"local.role=ebgp local.address={router['link_ip'].ip} "
+                f"remote.address={router['peer_ip']} remote.as={router['peer_as']} "
+                "output.redistribute=connected"
+            ),
+            "",
+        ]
+    )
+
+
+class RouterOsSimpleBGP(NetworkEnvBase):
+    LAB_NAME = "routeros_simple_bgp"
+    # Nested QEMU boot is slower than XRd's native-container boot.
+    VERIFY_MAX_WAIT_SEC = 600
+    VERIFY_RETRY_DELAY_SEC = 10
+    TOPO_LEVEL = "easy"
+    TOPO_SIZE = None
+    TAGS = ["arp", "link", "bgp", "icmp", "routeros", "pc"]
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.lab = Lab(self.LAB_NAME)
+        self.name = self.LAB_NAME
+        self.instance = Kathara.get_instance()
+        self.desc = (
+            "A simple BGP network with two MikroTik RouterOS routers and two pcs."
+        )
+
+        for router_name, router in ROUTERS.items():
+            machine = self.lab.new_machine(router_name, **{"image": IMAGE})
+            machine.add_meta("privileged", True)
+            machine.add_meta("env", f"CLAB_INTFS={CLAB_INTFS}")
+            # vrnetlab's default "vrxcon" datapath only wires a qemu netdev
+            # for a data interface that appears *after* boot (containerlab's
+            # model). Kathara attaches interfaces before the container
+            # starts, so eth1/eth2 already exist and vrxcon's -device ends up
+            # with no matching -netdev, crashing qemu immediately. "macvtap"
+            # instead wraps the already-present interface in a passthru
+            # macvtap, which is the datapath that matches Kathara's model.
+            machine.add_meta("args", "--connection-mode macvtap")
+            machine.create_file_from_string(
+                _build_startup_config(router_name, router),
+                "/ftpboot/config.auto.rsc",
+            )
+            # Consumes Kathara interface index 0 (RouterOS `ether1`, reserved
+            # by vrnetlab for its own mgmt bridge). Must be connected first.
+            self.lab.connect_machine_to_link(router_name, f"{router_name}_reserved0")
+
+        pc1 = self.lab.new_machine("pc1", **{"image": "kathara/nika-base"})
+        pc2 = self.lab.new_machine("pc2", **{"image": "kathara/nika-base"})
+
+        self.lab.connect_machine_to_link("router1", "A")
+        self.lab.connect_machine_to_link("router2", "A")
+
+        self.lab.connect_machine_to_link("router1", "B")
+        self.lab.connect_machine_to_link(pc1.name, "B")
+
+        self.lab.connect_machine_to_link("router2", "C")
+        self.lab.connect_machine_to_link(pc2.name, "C")
+
+        self.lab.create_file_from_string(
+            "ip addr add 195.11.14.2/24 dev eth0\n"
+            "ip route add default via 195.11.14.1 dev eth0\n",
+            "pc1.startup",
+        )
+        self.lab.create_file_from_string(
+            "ip addr add 200.1.1.2/24 dev eth0\n"
+            "ip route add default via 200.1.1.1 dev eth0\n",
+            "pc2.startup",
+        )
+
+        self.load_machines()
+
+    def deploy(self):
+        if not image_exists(IMAGE):
+            raise RuntimeError(
+                f"MikroTik RouterOS image {IMAGE!r} not found locally. It "
+                "must be built by hand from a downloaded CHR image, e.g.:\n"
+                "  git clone https://github.com/hellt/vrnetlab && "
+                "cd vrnetlab/mikrotik/routeros\n"
+                "  # copy the downloaded CHR .vmdk/.vdi into this directory\n"
+                "  make docker-image\n"
+                f"  docker tag <built-tag> {IMAGE}\n"
+                "See docs/mikrotik-routeros-setup.md for the full procedure."
+            )
+        super().deploy()
+
+    def verify_lab(self) -> dict:
+        from nika.net_env.kathara.interdomain_routing.routeros_simple_bgp.verify import (
+            verify_routeros_simple_bgp_lab,
+        )
+
+        return verify_routeros_simple_bgp_lab(
+            self._build_runtime(), scenario_name=self.LAB_NAME
+        )

--- a/src/nika/net_env/kathara/interdomain_routing/routeros_simple_bgp/verify.py
+++ b/src/nika/net_env/kathara/interdomain_routing/routeros_simple_bgp/verify.py
@@ -1,0 +1,85 @@
+"""Startup verification signals for the routeros_simple_bgp scenario."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nika.net_env.kathara.interdomain_routing.routeros_simple_bgp.lab import (
+    LINK_IFACE,
+    MGMT_ADDR,
+    MGMT_PASSWORD,
+    MGMT_USER,
+)
+from nika.net_env.verify import (
+    build_lab_verify_result,
+    default_route_via,
+    exec_or_empty,
+    host_has_ipv4,
+    nodes_deployed,
+    ping_ok,
+)
+from nika.runtime.base import LabRuntime
+
+# RouterOS's mgmt IP lives on vrnetlab's internal bridge, reachable only from
+# inside the container's network namespace. Commands stay free of embedded
+# double quotes: nika's exec wrapping (ShellResolver.wrap_shell_command)
+# mis-escapes them, the same issue IOSXRAPIMixin works around with single
+# quotes only.
+CLI_COMMAND = (
+    f"sshpass -p {MGMT_PASSWORD} ssh -q -oStrictHostKeyChecking=no "
+    f"-oConnectTimeout=1 {MGMT_USER}@{MGMT_ADDR} '{{command}}'"
+)
+
+
+def _routeros_interface_up(runtime: LabRuntime, router: str, interface: str) -> bool:
+    # `print terse` renders state as a single-letter flag (e.g. "R"), not as
+    # a "running=..." field, so it can't be substring-matched; filtering
+    # server-side on the (queryable but unlisted) `running` property instead
+    # returns the row only when it is actually up.
+    output = exec_or_empty(
+        runtime,
+        router,
+        CLI_COMMAND.format(
+            command=f"/interface print terse where name={interface} running=yes"
+        ),
+    )
+    return bool(output.strip())
+
+
+def _routeros_bgp_established(
+    runtime: LabRuntime, router: str, *, min_neighbors: int = 1
+) -> bool:
+    # Same story as `_routeros_interface_up`: state is the "E" flag, not a
+    # "state=established" field, so filter server-side on `established`.
+    output = exec_or_empty(
+        runtime,
+        router,
+        CLI_COMMAND.format(
+            command="/routing/bgp/session/print terse where established=yes"
+        ),
+        timeout=20,
+    )
+    established = len([line for line in output.splitlines() if line.strip()])
+    return established >= min_neighbors
+
+
+def verify_routeros_simple_bgp_lab(
+    runtime: LabRuntime, *, scenario_name: str
+) -> dict[str, Any]:
+    expected = ("router1", "router2", "pc1", "pc2")
+    checks = {
+        "nodes_deployed": nodes_deployed(runtime, expected),
+        "router1_iface_up": _routeros_interface_up(runtime, "router1", LINK_IFACE),
+        "router2_iface_up": _routeros_interface_up(runtime, "router2", LINK_IFACE),
+        "router1_bgp_established": _routeros_bgp_established(runtime, "router1"),
+        "pc1_ipv4": host_has_ipv4(runtime, "pc1", "195.11.14.2"),
+        "pc2_ipv4": host_has_ipv4(runtime, "pc2", "200.1.1.2"),
+        "pc1_default_route": default_route_via(runtime, "pc1", "195.11.14.1"),
+        "pc1_gateway_reachable": ping_ok(runtime, "pc1", "195.11.14.1"),
+        "pc1_to_pc2_reachable": ping_ok(runtime, "pc1", "200.1.1.2"),
+    }
+    return build_lab_verify_result(
+        scenario_name=scenario_name,
+        verified=all(checks.values()),
+        checks=checks,
+    )

--- a/src/nika/net_env/net_env_pool.py
+++ b/src/nika/net_env/net_env_pool.py
@@ -173,6 +173,13 @@ _NET_ENV_SPECS: dict[str, NetEnvSpec] = {
         tags=("arp", "link", "bgp", "icmp", "iosxr", "pc"),
         supported_backends=("kathara",),
     ),
+    "routeros_simple_bgp": NetEnvSpec(
+        lab_name="routeros_simple_bgp",
+        module="nika.net_env.kathara.interdomain_routing.routeros_simple_bgp.lab",
+        class_name="RouterOsSimpleBGP",
+        tags=("arp", "link", "bgp", "icmp", "routeros", "pc"),
+        supported_backends=("kathara",),
+    ),
     "isp": NetEnvSpec(
         lab_name="isp",
         module="nika.net_env.kathara.isp.isp.lab",

--- a/src/nika/service/kathara/__init__.py
+++ b/src/nika/service/kathara/__init__.py
@@ -5,6 +5,7 @@ from nika.service.kathara.intf_api import IntfAPIMixin, KatharaIntfAPI
 from nika.service.kathara.iosxr_api import IOSXRAPIMixin, KatharaIOSXRAPI
 from nika.service.kathara.k8s_api import KatharaK8sAPI, K8sAPIMixin
 from nika.service.kathara.nftable_api import KatharaNFTableAPI, NFTableMixin
+from nika.service.kathara.routeros_api import KatharaRouterOSAPI, RouterOSAPIMixin
 from nika.service.kathara.tc_api import KatharaTCAPI, TCMixin
 from nika.service.kathara.telemetry_api import KatharaTelemetryAPI, TelemetryAPIMixin
 
@@ -15,6 +16,7 @@ __all__ = [
     "KatharaFRRAPI",
     "KatharaIntfAPI",
     "KatharaIOSXRAPI",
+    "KatharaRouterOSAPI",
     "KatharaNFTableAPI",
     "KatharaTCAPI",
     "KatharaTelemetryAPI",
@@ -28,6 +30,7 @@ class KatharaAPIALL(
     FRRAPIMixin,
     IntfAPIMixin,
     IOSXRAPIMixin,
+    RouterOSAPIMixin,
     NFTableMixin,
     TCMixin,
     TelemetryAPIMixin,

--- a/src/nika/service/kathara/base_api.py
+++ b/src/nika/service/kathara/base_api.py
@@ -434,7 +434,7 @@ class KatharaBaseAPI:
             image = machine_obj.get_image()
             if "p4" in image:
                 self.bmv2_switches.append(machine)
-            elif "frr" in image or "xrd" in image:
+            elif "frr" in image or "xrd" in image or "routeros" in image:
                 self.routers.append(machine)
             elif "base" in image or "nginx" in image or "wireguard" in image:
                 host_keys = ["pc", "client"]

--- a/src/nika/service/kathara/routeros_api.py
+++ b/src/nika/service/kathara/routeros_api.py
@@ -1,0 +1,10 @@
+"""Kathara MikroTik RouterOS API (re-exported from shared lab service)."""
+
+from nika.service.kathara.base_api import KatharaBaseAPI
+from nika.service.lab.routeros_api import RouterOSAPIMixin
+
+__all__ = ["KatharaRouterOSAPI", "RouterOSAPIMixin"]
+
+
+class KatharaRouterOSAPI(KatharaBaseAPI, RouterOSAPIMixin):
+    pass

--- a/src/nika/service/lab/routeros_api.py
+++ b/src/nika/service/lab/routeros_api.py
@@ -1,0 +1,49 @@
+"""Shared MikroTik RouterOS routing API for Kathara labs."""
+
+from __future__ import annotations
+
+from nika.service.lab.protocols import SupportsExec
+
+# RouterOS's mgmt IP lives on vrnetlab's internal bridge, reachable only from
+# inside the container's network namespace. `vrnetlab`/`VR-netlab9` are
+# vrnetlab's own fixed, non-secret internal defaults for that loopback-only
+# segment, not real credentials protecting anything outside the container.
+MGMT_USER = "vrnetlab"
+MGMT_PASSWORD = "VR-netlab9"
+MGMT_ADDR = "172.31.255.30"
+
+CLI_COMMAND = (
+    f"sshpass -p {MGMT_PASSWORD} ssh -q -oStrictHostKeyChecking=no "
+    f"-oConnectTimeout=1 {MGMT_USER}@{MGMT_ADDR} '{{command}}'"
+)
+
+
+class RouterOSAPIMixin:
+    """RouterOS operations via ``exec_cmd`` over an internal, docker-exec-only SSH hop."""
+
+    def uses_routeros_router(self: SupportsExec, device_name: str) -> bool:
+        output = self.exec_cmd(device_name, "which sshpass && echo yes || true")
+        return "yes" in output
+
+    def routeros_exec(self: SupportsExec, device_name: str, command: str) -> str:
+        # RouterOS CLI values needed here (IPs, interface names, AS numbers)
+        # never contain spaces, so commands stay free of embedded double
+        # quotes — nika's exec wrapping mis-escapes those.
+        return self.exec_cmd(device_name, CLI_COMMAND.format(command=command))
+
+    def routeros_show_interfaces(self: SupportsExec, device_name: str) -> str:
+        return self.routeros_exec(device_name, "/interface print")
+
+    def routeros_get_bgp_conf(self: SupportsExec, device_name: str) -> str:
+        return self.routeros_exec(device_name, "/routing bgp connection print detail")
+
+    def routeros_show_route(self: SupportsExec, device_name: str) -> str:
+        return self.routeros_exec(device_name, "/ip route print")
+
+    def routeros_apply_config(
+        self: SupportsExec, device_name: str, config_lines: list[str]
+    ) -> str:
+        # RouterOS has no single-shot config-blob apply like XRd's
+        # xrapply_string; chain the discrete CLI commands in one SSH hop.
+        command = "; ".join(config_lines)
+        return self.routeros_exec(device_name, command)

--- a/src/nika/service/mcp_gateway/app.py
+++ b/src/nika/service/mcp_gateway/app.py
@@ -42,6 +42,10 @@ _MCP_MODULE_ATTRS: dict[str, tuple[str, str]] = {
         "nika.service.mcp_server.kathara.iosxr_server",
         "mcp",
     ),
+    "kathara_routeros_mcp_server": (
+        "nika.service.mcp_server.kathara.routeros_server",
+        "mcp",
+    ),
     "kathara_bmv2_mcp_server": (
         "nika.service.mcp_server.kathara.bmv2_server",
         "mcp",

--- a/src/nika/service/mcp_server/kathara/routeros_server.py
+++ b/src/nika/service/mcp_server/kathara/routeros_server.py
@@ -1,0 +1,64 @@
+from mcp.server.fastmcp import FastMCP
+
+from nika.service.kathara import KatharaRouterOSAPI
+from nika.service.mcp_server.session_context import get_lab_name
+from nika.utils.errors import safe_tool
+
+# Initialize FastMCP server
+mcp = FastMCP("kathara_routeros_mcp_server")
+
+
+@safe_tool
+@mcp.tool()
+def routeros_get_bgp_conf(router_name: str) -> str:
+    """Get the BGP connection configuration from the RouterOS router.
+
+    Args:
+        router_name (str): The name of the router.
+
+    Returns:
+        str: The BGP connection configuration from the RouterOS router.
+    """
+    kathara_api = KatharaRouterOSAPI(lab_name=get_lab_name())
+    return kathara_api.routeros_get_bgp_conf(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def routeros_show_interfaces(router_name: str) -> str:
+    """Get the interface list from the RouterOS router.
+
+    Args:
+        router_name (str): The name of the router.
+    Returns:
+        str: The interface list from the RouterOS router.
+    """
+    kathara_api = KatharaRouterOSAPI(lab_name=get_lab_name())
+    return kathara_api.routeros_show_interfaces(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def routeros_show_route(router_name: str) -> str:
+    """Get the IP routing table from the RouterOS router.
+
+    Args:
+        router_name (str): The name of the router.
+    Returns:
+        str: The IP routing table from the RouterOS router.
+    """
+    kathara_api = KatharaRouterOSAPI(lab_name=get_lab_name())
+    return kathara_api.routeros_show_route(router_name)
+
+
+@safe_tool
+@mcp.tool()
+def routeros_exec(router_name: str, command: str) -> str:
+    """Execute a RouterOS CLI command on a RouterOS router."""
+    kathara_api = KatharaRouterOSAPI(lab_name=get_lab_name())
+    return kathara_api.routeros_exec(router_name, command)
+
+
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport="stdio")

--- a/src/nika/service/mcp_server/registry.py
+++ b/src/nika/service/mcp_server/registry.py
@@ -15,6 +15,7 @@ ENV_SESSION_BACKEND = "NIKA_SESSION_BACKEND"
 # Keyword tokens (from scenario name and net-env TAGS) that trigger optional servers.
 ROUTING_KEYWORDS = frozenset({"bgp", "ospf", "rip", "frr", "routing"})
 IOSXR_KEYWORDS = frozenset({"iosxr", "xrd"})
+ROUTEROS_KEYWORDS = frozenset({"mikrotik", "routeros"})
 SWITCH_KEYWORDS = frozenset({"p4", "bmv2", "sdn", "bloom", "mpls", "int", "counter"})
 TELEMETRY_KEYWORDS = frozenset({"telemetry"})
 KUBERNETES_KEYWORDS = frozenset({"kubernetes", "k3s", "k8s"})
@@ -67,6 +68,12 @@ MCP_SERVER_SPECS: dict[str, MCPServerSpec] = {
         backend="kathara",
         role="routing",
         module="kathara/iosxr_server.py",
+    ),
+    "kathara_routeros_mcp_server": MCPServerSpec(
+        name="kathara_routeros_mcp_server",
+        backend="kathara",
+        role="routing",
+        module="kathara/routeros_server.py",
     ),
     "kathara_bmv2_mcp_server": MCPServerSpec(
         name="kathara_bmv2_mcp_server",
@@ -171,6 +178,8 @@ def select_diagnosis_servers(
         servers.append("containerlab_srl_mcp_server")
     elif backend != "containerlab" and tokens & IOSXR_KEYWORDS:
         servers.append("kathara_iosxr_mcp_server")
+    elif backend != "containerlab" and tokens & ROUTEROS_KEYWORDS:
+        servers.append("kathara_routeros_mcp_server")
     elif backend != "containerlab" and tokens & ROUTING_KEYWORDS:
         servers.append("kathara_frr_mcp_server")
     if tokens & SWITCH_KEYWORDS:

--- a/tests/nika/net_env/test_routeros_simple_bgp_verify.py
+++ b/tests/nika/net_env/test_routeros_simple_bgp_verify.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from nika.net_env.kathara.interdomain_routing.routeros_simple_bgp.verify import (
+    CLI_COMMAND,
+    verify_routeros_simple_bgp_lab,
+)
+from tests.support.net_env import assert_verify_success
+
+NODES = {"router1", "router2", "pc1", "pc2"}
+HOST_ADDRS = {
+    "pc1": ("195.11.14.2",),
+    "pc2": ("200.1.1.2",),
+}
+
+IFACE_CMD = CLI_COMMAND.format(
+    command="/interface print terse where name=ether2 running=yes"
+)
+BGP_CMD = CLI_COMMAND.format(
+    command="/routing/bgp/session/print terse where established=yes"
+)
+
+
+class FakeRuntime:
+    def __init__(self, *, nodes: set[str] | None = None) -> None:
+        self.nodes = nodes or NODES
+
+    def list_nodes(self) -> list[str]:
+        return sorted(self.nodes)
+
+    def exec(self, host: str, command: str, timeout: float = 10.0) -> str:
+        if command == IFACE_CMD:
+            return "0 R ether2\n"
+        if command == BGP_CMD:
+            return "0 name=to-peer remote.address=193.10.11.2\n"
+        if command.startswith("ping -c 1"):
+            return "1 received"
+        if command.startswith("ip -4 -o addr show"):
+            return "\n".join(f"inet {addr}/24" for addr in HOST_ADDRS.get(host, ()))
+        if command == "ip route show default":
+            return "default via 195.11.14.1 dev eth0"
+        return ""
+
+
+def test_routeros_simple_bgp_verify_passes() -> None:
+    assert_verify_success(
+        verify_routeros_simple_bgp_lab(FakeRuntime(), scenario_name="x")
+    )
+
+
+def test_routeros_simple_bgp_verify_fails_on_missing_node() -> None:
+    result = verify_routeros_simple_bgp_lab(
+        FakeRuntime(nodes=NODES - {"pc2"}), scenario_name="x"
+    )
+    assert not result["verified"]
+    assert not result["checks"]["nodes_deployed"]


### PR DESCRIPTION
This pull request adds support for a new MikroTik RouterOS-based BGP scenario (`routeros_simple_bgp`) to the NIKA network benchmarking framework. It introduces a new scenario that uses vrnetlab-wrapped RouterOS VMs, updates documentation, and ensures the codebase recognizes and interacts with RouterOS nodes appropriately. The most important changes are as follows:

**New Scenario: MikroTik RouterOS BGP**

* Added the `routeros_simple_bgp` scenario, which deploys a two-AS BGP topology using MikroTik RouterOS routers running inside vrnetlab QEMU containers. The implementation includes lab definition, startup configuration, deployment checks for the required image, and a scenario-specific verification routine. 

**Documentation Updates**

* Updated `network-scenarios.md` and `README.md` to describe the new `routeros_simple_bgp` scenario, its requirements, and its differences from the FRR and Cisco XRd variants. Added a detailed setup guide for building and deploying the required RouterOS vrnetlab image. 

**Core Framework Enhancements**

* Updated the base network environment code to recognize RouterOS images as routers and to ignore vrnetlab's internal placeholder links when building the reported topology. 

**Service Layer Integration**

* Integrated RouterOS support into the Kathara service API by importing and exposing `KatharaRouterOSAPI` and its mixin, and including it in the unified Kathara API class. 

**Testing/Mocking**

* Updated the mock agent to recognize and mock diagnosis tool calls for RouterOS-based scenarios.