### PR TITLE
Propagate run-config YAML into benchmark trial subprocesses

### DIFF
--- a/src/nika/cli/commands/agent.py
+++ b/src/nika/cli/commands/agent.py
@@ -5,6 +5,7 @@ import typer
 from agent.cli.codex.codex_worker import REASONING_EFFORT_LEVELS
 from nika.run_config.loader import (
     ENV_RUN_CONFIG,
+    export_run_config_env,
     load_run_config,
     merge_cli,
     set_run_config,
@@ -58,7 +59,8 @@ def _activate_run_config(
     sandbox_upstream_proxy: str | None,
 ) -> None:
     warn_legacy_operational_env()
-    cfg = load_run_config(run_config)
+    cfg_path = export_run_config_env(run_config)
+    cfg = load_run_config(cfg_path)
     cfg = merge_cli(
         cfg,
         agent_type=agent_type,

--- a/src/nika/cli/commands/benchmark.py
+++ b/src/nika/cli/commands/benchmark.py
@@ -7,12 +7,19 @@ import typer
 from nika.net_env.net_env_pool import scenario_requires_topo_size
 from nika.run_config.loader import (
     ENV_RUN_CONFIG,
+    export_run_config_env,
     load_run_config,
     merge_cli,
     set_run_config,
 )
 from nika.run_config.legacy import warn_legacy_operational_env
-from nika.utils.agent_config import apply_custom_provider_env
+from nika.utils.agent_config import (
+    apply_custom_provider_env,
+    resolve_agent_model,
+    resolve_agent_type,
+    resolve_llm_provider,
+    resolve_max_steps,
+)
 from nika.workflows.benchmark.release import (
     DEFAULT_RELEASE_VERSION,
     ReleaseError,
@@ -245,7 +252,10 @@ def benchmark_run(
     benchmark candidate catalog.
     """
     warn_legacy_operational_env()
-    cfg = load_run_config(run_config)
+    # Spawn trial workers inherit process env, not ContextVar; export the path
+    # so children reload the same YAML (skills, sandbox, MCP, agent defaults).
+    cfg_path = export_run_config_env(run_config)
+    cfg = load_run_config(cfg_path)
     cfg = merge_cli(
         cfg,
         agent_type=agent_type,
@@ -265,6 +275,15 @@ def benchmark_run(
     )
     set_run_config(cfg)
     apply_custom_provider_env(cfg)
+    # Resolve before scheduling so spawn kwargs are concrete when CLI omitted them.
+    agent_type = resolve_agent_type(agent_type, config=cfg)
+    llm_provider = resolve_llm_provider(
+        llm_provider, agent_type=agent_type, config=cfg
+    )
+    model = resolve_agent_model(
+        agent_type, model, llm_provider=llm_provider, config=cfg
+    )
+    max_steps = resolve_max_steps(max_steps, config=cfg)
 
     bench = cfg.benchmark
     resolved_batch_size = bench.batch_size

--- a/src/nika/cli/commands/evaluation.py
+++ b/src/nika/cli/commands/evaluation.py
@@ -5,6 +5,7 @@ import typer
 from nika.config import ENV_RESULT_DIR
 from nika.run_config.loader import (
     ENV_RUN_CONFIG,
+    export_run_config_env,
     load_run_config,
     merge_cli,
     set_run_config,
@@ -34,7 +35,8 @@ def eval_metrics(
 ) -> None:
     """Compute rule-based scores and trace stats on closed session(s); write eval_metrics.json."""
     warn_legacy_operational_env()
-    cfg = merge_cli(load_run_config(run_config), result_dir=result_dir)
+    cfg_path = export_run_config_env(run_config)
+    cfg = merge_cli(load_run_config(cfg_path), result_dir=result_dir)
     set_run_config(cfg)
 
     from nika.workflows.eval.session import run_eval_metrics
@@ -76,8 +78,9 @@ def eval_judge(
 ) -> None:
     """Run LLM-as-judge on closed session(s); write llm_judge.json."""
     warn_legacy_operational_env()
+    cfg_path = export_run_config_env(run_config)
     cfg = merge_cli(
-        load_run_config(run_config),
+        load_run_config(cfg_path),
         result_dir=result_dir,
         judge_provider=judge_provider,
         judge_model=judge_model,

--- a/src/nika/run_config/__init__.py
+++ b/src/nika/run_config/__init__.py
@@ -4,10 +4,12 @@ from nika.run_config.loader import (
     ENV_RUN_CONFIG,
     default_run_config_path,
     dump_run_config,
+    export_run_config_env,
     get_run_config,
     load_run_config,
     merge_cli,
     reset_run_config,
+    resolve_run_config_path,
     set_run_config,
 )
 from nika.run_config.schema import RunConfig, default_run_config
@@ -18,9 +20,11 @@ __all__ = [
     "default_run_config",
     "default_run_config_path",
     "dump_run_config",
+    "export_run_config_env",
     "get_run_config",
     "load_run_config",
     "merge_cli",
     "reset_run_config",
+    "resolve_run_config_path",
     "set_run_config",
 ]

--- a/src/nika/run_config/loader.py
+++ b/src/nika/run_config/loader.py
@@ -31,12 +31,25 @@ def default_run_config_path() -> Path:
     return (REPO_ROOT / DEFAULT_RUN_CONFIG_REL).resolve()
 
 
+def resolve_run_config_path(path: str | Path | None = None) -> Path:
+    """Resolve a run-config path to an absolute path (REPO_ROOT-relative allowed)."""
+    cfg_path = Path(path) if path is not None else default_run_config_path()
+    if not cfg_path.is_absolute():
+        return (REPO_ROOT / cfg_path).resolve()
+    return cfg_path.resolve()
+
+
+def export_run_config_env(path: str | Path | None = None) -> Path:
+    """Export ``NIKA_RUN_CONFIG`` so spawn children reload the same YAML file."""
+    cfg_path = resolve_run_config_path(path)
+    os.environ[ENV_RUN_CONFIG] = str(cfg_path)
+    return cfg_path
+
+
 def load_run_config(path: str | Path | None = None) -> RunConfig:
     """Load YAML run config; missing file → code defaults."""
     global _warned_missing
-    cfg_path = Path(path) if path is not None else default_run_config_path()
-    if not cfg_path.is_absolute():
-        cfg_path = (REPO_ROOT / cfg_path).resolve()
+    cfg_path = resolve_run_config_path(path)
 
     if not cfg_path.is_file():
         if not _warned_missing:

--- a/src/nika/run_config/loader.py
+++ b/src/nika/run_config/loader.py
@@ -23,20 +23,27 @@ _current: ContextVar[RunConfig | None] = ContextVar("nika_run_config", default=N
 _warned_missing = False
 
 
+def _absolutize_run_config_path(cfg_path: Path) -> Path:
+    cfg_path = cfg_path.expanduser()
+    if not cfg_path.is_absolute():
+        return (REPO_ROOT / cfg_path).resolve()
+    return cfg_path.resolve()
+
+
 def default_run_config_path() -> Path:
     raw = os.environ.get(ENV_RUN_CONFIG, "").strip()
     if raw:
-        path = Path(raw)
-        return path if path.is_absolute() else (REPO_ROOT / path).resolve()
+        return _absolutize_run_config_path(Path(raw))
     return (REPO_ROOT / DEFAULT_RUN_CONFIG_REL).resolve()
 
 
 def resolve_run_config_path(path: str | Path | None = None) -> Path:
     """Resolve a run-config path to an absolute path (REPO_ROOT-relative allowed)."""
-    cfg_path = Path(path) if path is not None else default_run_config_path()
-    if not cfg_path.is_absolute():
-        return (REPO_ROOT / cfg_path).resolve()
-    return cfg_path.resolve()
+    if path is not None and not str(path).strip():
+        path = None
+    if path is None:
+        return default_run_config_path()
+    return _absolutize_run_config_path(Path(path))
 
 
 def export_run_config_env(path: str | Path | None = None) -> Path:

--- a/tests/nika/test_run_config.py
+++ b/tests/nika/test_run_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -11,11 +12,19 @@ from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from nika.cli.main import app
+from nika.config import REPO_ROOT
 from nika.run_config.legacy import (
     detect_legacy_operational_env,
     warn_legacy_operational_env,
 )
-from nika.run_config.loader import load_run_config, merge_cli
+from nika.run_config.loader import (
+    DEFAULT_RUN_CONFIG_REL,
+    ENV_RUN_CONFIG,
+    export_run_config_env,
+    load_run_config,
+    merge_cli,
+    resolve_run_config_path,
+)
 from nika.run_config.schema import RunConfig
 
 _RUNNER = CliRunner()
@@ -26,6 +35,42 @@ def test_load_missing_uses_defaults(tmp_path: Path) -> None:
     assert cfg.agent.type == "byo.langgraph"
     assert cfg.agent.max_steps == 20
     assert cfg.benchmark.case_timeout_sec == 2400
+
+
+def test_resolve_run_config_path_relative_and_absolute(tmp_path: Path) -> None:
+    abs_path = (tmp_path / "nika.yaml").resolve()
+    assert resolve_run_config_path(abs_path) == abs_path
+    assert resolve_run_config_path("config/nika.yaml") == (
+        REPO_ROOT / "config" / "nika.yaml"
+    ).resolve()
+
+
+def test_resolve_run_config_path_blank_and_home(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ENV_RUN_CONFIG, raising=False)
+    default = (REPO_ROOT / DEFAULT_RUN_CONFIG_REL).resolve()
+    assert resolve_run_config_path("") == default
+    assert resolve_run_config_path("   ") == default
+
+    home_cfg = tmp_path / "home-nika.yaml"
+    home_cfg.write_text("version: 1\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert resolve_run_config_path("~/home-nika.yaml") == home_cfg.resolve()
+
+
+def test_export_run_config_env_sets_absolute(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "custom.yaml"
+    target.write_text("version: 1\n", encoding="utf-8")
+    monkeypatch.delenv(ENV_RUN_CONFIG, raising=False)
+    exported = export_run_config_env(target)
+    assert exported == target.resolve()
+    assert Path(os.environ[ENV_RUN_CONFIG]).resolve() == exported
+
+    monkeypatch.setenv(ENV_RUN_CONFIG, "")
+    exported_default = export_run_config_env("")
+    assert exported_default == (REPO_ROOT / DEFAULT_RUN_CONFIG_REL).resolve()
+    assert Path(os.environ[ENV_RUN_CONFIG]).resolve() == exported_default
 
 
 def test_static_validation_yaml_has_only_enabled_flag() -> None:


### PR DESCRIPTION
Trial workers previously only saw CLI flags, so YAML agent/model defaults were ignored inside subprocessed. Now fixed by propagate the yaml into trial subprocesses.